### PR TITLE
Add intervention analysis module and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Cristify-STL/
 
 * [ ] Embedded gallery view with previews
 
+## 🧠 Intelligent Mesh Intervention Strategy
+
+Cristify STL aspires to become an intelligent assistant that intervenes in 3D geometry only when it can meaningfully contribute.
+It analyzes mesh structure, projects potential transformations, estimates their impact, and requests human input only when its expected contribution is minimal.
+This hybrid architecture blends geometric structure, probabilistic learning, and aesthetic judgment.
+
 ---
 
 ## 🚀 Getting Started for Developers

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,1 +1,5 @@
 """Core functionality for Cristify STL."""
+
+from .intervention import analyze_mesh
+
+__all__ = ["analyze_mesh"]

--- a/app/core/intervention.py
+++ b/app/core/intervention.py
@@ -1,0 +1,58 @@
+"""Mesh intervention analysis utilities.
+
+This module provides experimental heuristics for identifying areas of a mesh
+that might benefit from geometric interventions. The logic is intentionally
+lightweight and does not modify geometry. It returns scores that future
+components can use to decide whether to apply transformations.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import trimesh
+
+
+def analyze_mesh(mesh: trimesh.Trimesh) -> Dict[str, float | int | bool]:
+    """Analyze a mesh and compute intervention metrics.
+
+    Parameters
+    ----------
+    mesh:
+        The :class:`trimesh.Trimesh` object to inspect.
+
+    Returns
+    -------
+    dict
+        Dictionary containing heuristic metrics.
+    """
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise TypeError("mesh must be a trimesh.Trimesh instance")
+
+    result: Dict[str, float | int | bool] = {}
+
+    result["has_holes"] = not mesh.is_watertight
+
+    unique_idx, counts = np.unique(mesh.edges_unique_inverse, return_counts=True)
+    isolated_edges = mesh.edges_unique[counts == 1]
+    result["isolated_edges"] = int(len(isolated_edges))
+
+    normals = mesh.face_normals
+    if normals.size:
+        vertical = np.array([0.0, 0.0, 1.0])
+        cos_angles = np.abs(normals.dot(vertical))
+        flat_faces = cos_angles > 0.98
+        result["flat_face_ratio"] = float(flat_faces.sum()) / len(normals)
+    else:
+        result["flat_face_ratio"] = 0.0
+
+    score = 0.0
+    if result["has_holes"]:
+        score += 0.5
+    if mesh.edges_unique.shape[0] > 0:
+        score += 0.3 * (result["isolated_edges"] / mesh.edges_unique.shape[0])
+    score += 0.2 * result["flat_face_ratio"]
+
+    result["intervention_score"] = round(score, 3)
+    return result

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -1,0 +1,12 @@
+import pytest
+import trimesh
+
+from app.core import analyze_mesh
+
+
+def test_analyze_mesh_box():
+    mesh = trimesh.primitives.Box()
+    result = analyze_mesh(mesh)
+    assert isinstance(result, dict)
+    assert result["has_holes"] is False
+    assert 0.0 <= result["intervention_score"] <= 1.0


### PR DESCRIPTION
## Summary
- document the Intelligent Mesh Intervention Strategy
- expose new `analyze_mesh` helper
- implement formative analysis heuristics
- test mesh intervention scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684309815c7883229e4a1a3705f1ebee