### PR TITLE
Implement cristify_mesh transformation

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,5 +1,6 @@
 """Core functionality for Cristify STL."""
 
 from .intervention import analyze_mesh
+from .cristify import cristify_mesh
 
-__all__ = ["analyze_mesh"]
+__all__ = ["analyze_mesh", "cristify_mesh"]

--- a/app/core/cristify.py
+++ b/app/core/cristify.py
@@ -1,1 +1,51 @@
-"""Cristify core logic placeholder."""
+"""Mesh transformation utilities for Cristify STL."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+
+
+def cristify_mesh(mesh: trimesh.Trimesh, amount: float = 1.0) -> trimesh.Trimesh:
+    """Project vertices downward to create a draped effect.
+
+    Each vertex is translated along the negative ``Z`` axis by ``amount`` times
+    its distance from the top of the mesh. The original mesh is not modified.
+
+    Parameters
+    ----------
+    mesh:
+        Input mesh to transform.
+    amount:
+        Scale factor for the downward displacement. ``1.0`` moves each vertex by
+        its full distance from the top, ``0`` leaves the mesh unchanged.
+
+    Returns
+    -------
+    trimesh.Trimesh
+        A new mesh instance with transformed vertices.
+    """
+
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise TypeError("mesh must be a trimesh.Trimesh instance")
+
+    if not np.isscalar(amount):
+        raise TypeError("amount must be a scalar numeric value")
+
+    vertices = mesh.vertices.view(np.ndarray)
+    faces = mesh.faces.view(np.ndarray)
+
+    max_z = float(vertices[:, 2].max()) if len(vertices) else 0.0
+
+    new_vertices = vertices.copy()
+    distances = max_z - vertices[:, 2]
+    new_vertices[:, 2] -= distances * float(amount)
+
+    new_mesh = trimesh.Trimesh(
+        vertices=new_vertices,
+        faces=faces.copy(),
+        process=False,
+    )
+
+    return new_mesh
+

--- a/tests/test_cristify.py
+++ b/tests/test_cristify.py
@@ -1,0 +1,31 @@
+import pytest
+import numpy as np
+import trimesh
+
+from app.core import cristify_mesh
+
+
+def test_cristify_box_basic():
+    mesh = trimesh.primitives.Box(extents=(1, 1, 1))
+    original_min_z = mesh.vertices[:, 2].min()
+    original_max_z = mesh.vertices[:, 2].max()
+
+    result = cristify_mesh(mesh, amount=1.0)
+
+    # original mesh should remain unchanged
+    assert mesh.vertices[:, 2].min() == pytest.approx(original_min_z)
+    assert mesh.vertices[:, 2].max() == pytest.approx(original_max_z)
+
+    # transformed mesh
+    assert isinstance(result, trimesh.Trimesh)
+    assert result is not mesh
+
+    assert result.vertices[:, 2].max() == pytest.approx(original_max_z)
+    expected_min = original_min_z - (original_max_z - original_min_z)
+    assert result.vertices[:, 2].min() == pytest.approx(expected_min)
+
+
+def test_cristify_zero_amount():
+    mesh = trimesh.primitives.Box(extents=(1, 1, 1))
+    result = cristify_mesh(mesh, amount=0.0)
+    assert np.allclose(mesh.vertices, result.vertices)


### PR DESCRIPTION
## Summary
- implement `cristify_mesh` for creating a draped effect on meshes
- expose `cristify_mesh` in core package
- add unit tests covering cristify functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430ce4fc908322ab0b5c977dd721da