### PR TITLE
Add CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ pip install -r requirements-dev.txt
 python app/gui/main_gui.py
 ```
 
+## 📟 Command Line Usage
+
+You can also transform meshes directly from the terminal:
+
+```bash
+python -m app.cli --input model.stl --output draped.stl --amount 1.5
+```
+
 ---
 
 ## 🌈 Project Philosophy

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,38 @@
+"""Command-line interface for Cristify STL."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from app.core.io import load_mesh, save_mesh
+from app.core.cristify import cristify_mesh
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Cristify an STL mesh")
+    parser.add_argument("--input", required=True, help="Path to input STL file")
+    parser.add_argument(
+        "--output", required=True, help="Destination path for transformed mesh"
+    )
+    parser.add_argument(
+        "--amount",
+        type=float,
+        default=1.0,
+        help="Cristify amount scale factor",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: Sequence[str] | None = None) -> int:
+    opts = parse_args(args)
+
+    mesh = load_mesh(opts.input)
+    result = cristify_mesh(mesh, amount=opts.amount)
+    save_mesh(result, opts.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+
+import pytest
+import trimesh
+
+from app.core.io import load_mesh
+
+
+def test_cli_cristify(tmp_path):
+    input_path = tmp_path / "in.stl"
+    output_path = tmp_path / "out.stl"
+
+    trimesh.primitives.Box().export(input_path)
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "app.cli",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--amount",
+            "0.5",
+        ]
+    )
+
+    assert output_path.exists()
+    result = load_mesh(str(output_path))
+    assert isinstance(result, trimesh.Trimesh)
+    assert result.vertices[:, 2].min() < trimesh.load(str(input_path)).vertices[:, 2].min()
+


### PR DESCRIPTION
## Summary
- add a simple argparse-based CLI under `app/cli.py`
- document CLI usage in README
- test CLI via subprocess

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430de997b88322b8553e8d1c8e3c0e