### PR TITLE
Implement basic DearPyGui GUI

### DIFF
--- a/app/gui/main_gui.py
+++ b/app/gui/main_gui.py
@@ -1,1 +1,102 @@
-"""Main GUI entry point placeholder."""
+"""Basic DearPyGui interface for Cristify STL.
+
+This module wires together a minimal workflow:
+
+1. Load an STL file.
+2. Apply :func:`cristify_mesh` to the mesh.
+3. Save the result.
+
+The interface deliberately keeps functionality simple.  It relies on the
+``MeshViewer`` from :mod:`app.gui.viewer` to show a small preview of the
+current mesh.  The goal is to demonstrate interaction rather than provide
+an advanced editor.
+"""
+
+from __future__ import annotations
+
+import dearpygui.dearpygui as dpg
+
+from app.core.cristify import cristify_mesh
+from app.core.io import load_mesh, save_mesh
+from app.gui.viewer import MeshViewer
+
+_current_mesh = None
+_viewer: MeshViewer
+
+
+def _open_load_dialog() -> None:
+    dpg.show_item("load_dialog")
+
+
+def _open_save_dialog() -> None:
+    dpg.show_item("save_dialog")
+
+
+def _on_load_dialog(sender, app_data: dict) -> None:  # pragma: no cover - UI
+    global _current_mesh
+    try:
+        path = app_data.get("file_path_name")
+        if path:
+            _current_mesh = load_mesh(path)
+            _viewer.set_mesh(_current_mesh)
+    except Exception as exc:  # pragma: no cover - debug output
+        print(f"Failed to load mesh: {exc}")
+
+
+def _on_save_dialog(sender, app_data: dict) -> None:  # pragma: no cover - UI
+    if _current_mesh is None:
+        return
+    try:
+        path = app_data.get("file_path_name")
+        if path:
+            save_mesh(_current_mesh, path)
+    except Exception as exc:  # pragma: no cover - debug output
+        print(f"Failed to save mesh: {exc}")
+
+
+def _apply_cristify() -> None:  # pragma: no cover - UI
+    global _current_mesh
+    if _current_mesh is None:
+        return
+    _current_mesh = cristify_mesh(_current_mesh)
+    _viewer.set_mesh(_current_mesh)
+
+
+def main() -> None:  # pragma: no cover - manual run
+    """Launch the GUI application."""
+
+    dpg.create_context()
+
+    global _viewer
+    _viewer = MeshViewer()
+
+    with dpg.window(label="Cristify STL", width=200, height=150):
+        dpg.add_button(label="Load STL", callback=_open_load_dialog)
+        dpg.add_button(label="Apply Cristify", callback=_apply_cristify)
+        dpg.add_button(label="Save STL", callback=_open_save_dialog)
+
+    with dpg.file_dialog(
+        directory_selector=False, callback=_on_load_dialog, show=False, tag="load_dialog"
+    ):
+        dpg.add_file_extension(".stl", color=(0, 255, 0, 255))
+
+    with dpg.file_dialog(
+        directory_selector=False,
+        callback=_on_save_dialog,
+        show=False,
+        tag="save_dialog",
+        default_filename="cristified.stl",
+    ):
+        dpg.add_file_extension(".stl", color=(0, 255, 0, 255))
+
+    dpg.create_viewport(title="Cristify STL", width=800, height=600)
+    dpg.setup_dearpygui()
+    dpg.show_viewport()
+    _viewer.show()
+    dpg.start_dearpygui()
+    dpg.destroy_context()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()
+

--- a/app/gui/viewer.py
+++ b/app/gui/viewer.py
@@ -1,1 +1,99 @@
-"""3D viewer placeholder."""
+"""Minimal DearPyGui based 3D viewer.
+
+This module provides a :class:`MeshViewer` used by ``main_gui.py`` to
+display a very small preview of the currently loaded mesh.  It avoids
+any heavyweight OpenGL features so it can run in constrained
+environments where a full graphics stack may not be available.  The
+viewer simply projects mesh triangles onto the XY plane after applying
+a small rotation.  The result is drawn using DearPyGui's draw list
+API.  The implementation is intentionally lightweight but gives a
+useful approximation of the model inside the GUI.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import dearpygui.dearpygui as dpg
+import trimesh
+
+
+class MeshViewer:
+    """Very small helper to render a mesh inside a DearPyGui drawlist."""
+
+    def __init__(self, *, tag: str = "viewer_window", size: int = 400) -> None:
+        self._mesh: Optional[trimesh.Trimesh] = None
+        self._rotation: float = 0.0
+        self.size = size
+
+        with dpg.window(label="Preview", tag=tag):
+            self.drawlist = dpg.add_drawlist(width=size, height=size)
+        self.window_tag = tag
+
+    # ------------------------------------------------------------------
+    def set_mesh(self, mesh: trimesh.Trimesh) -> None:
+        """Set the mesh to display and redraw."""
+
+        self._mesh = mesh
+        self._rotation = 0.0
+        self._draw()
+
+    # ------------------------------------------------------------------
+    def rotate(self, degrees: float) -> None:
+        """Rotate the preview and redraw."""
+
+        if self._mesh is None:
+            return
+        self._rotation += float(degrees)
+        self._draw()
+
+    # ------------------------------------------------------------------
+    def show(self) -> None:
+        """Make sure the preview window is visible."""
+
+        dpg.show_item(self.window_tag)
+
+    # ------------------------------------------------------------------
+    def _draw(self) -> None:
+        """Internal helper to draw the projected mesh."""
+
+        dpg.delete_item(self.drawlist, children_only=True)
+        if self._mesh is None or self._mesh.vertices.size == 0:
+            return
+
+        verts = self._mesh.vertices
+        faces = self._mesh.faces
+
+        angle = np.deg2rad(self._rotation)
+        rot = np.array(
+            [
+                [np.cos(angle), 0.0, np.sin(angle)],
+                [0.0, 1.0, 0.0],
+                [-np.sin(angle), 0.0, np.cos(angle)],
+            ]
+        )
+
+        projected = (verts @ rot.T)[:, :2]
+
+        min_xy = projected.min(axis=0)
+        max_xy = projected.max(axis=0)
+        extent = float(max(max_xy - min_xy))
+        if extent == 0.0:
+            extent = 1.0
+        scale = (self.size - 40) / extent
+        offset = (min_xy + max_xy) / 2.0
+
+        projected = (projected - offset) * scale + self.size / 2.0
+
+        for tri in faces:
+            pts = projected[tri]
+            dpg.draw_triangle(
+                self.drawlist,
+                *pts[0],
+                *pts[1],
+                *pts[2],
+                color=(200, 200, 200, 255),
+                fill=(100, 150, 230, 100),
+            )
+


### PR DESCRIPTION
## Summary
- flesh out `main_gui.py` with a minimal DearPyGui window
- implement `MeshViewer` that draws a simple projection of the mesh
- hook load, cristify, and save actions to the viewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430eca48048322a3e771d70ddfdce4