### PR TITLE
Remove unused import and satisfy flake8

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -12,7 +12,11 @@ from app.core.cristify import cristify_mesh
 def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Cristify an STL mesh")
-    parser.add_argument("--input", required=True, help="Path to input STL file")
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to input STL file",
+    )
     parser.add_argument(
         "--output", required=True, help="Destination path for transformed mesh"
     )

--- a/app/core/cristify.py
+++ b/app/core/cristify.py
@@ -6,7 +6,10 @@ import numpy as np
 import trimesh
 
 
-def cristify_mesh(mesh: trimesh.Trimesh, amount: float = 1.0) -> trimesh.Trimesh:
+def cristify_mesh(
+    mesh: trimesh.Trimesh,
+    amount: float = 1.0,
+) -> trimesh.Trimesh:
     """Project vertices downward to create a draped effect.
 
     Each vertex is translated along the negative ``Z`` axis by ``amount`` times
@@ -17,8 +20,9 @@ def cristify_mesh(mesh: trimesh.Trimesh, amount: float = 1.0) -> trimesh.Trimesh
     mesh:
         Input mesh to transform.
     amount:
-        Scale factor for the downward displacement. ``1.0`` moves each vertex by
-        its full distance from the top, ``0`` leaves the mesh unchanged.
+        Scale factor for the downward displacement. ``1.0`` moves each
+        vertex by its full distance from the top, ``0`` leaves the mesh
+        unchanged.
 
     Returns
     -------
@@ -48,4 +52,3 @@ def cristify_mesh(mesh: trimesh.Trimesh, amount: float = 1.0) -> trimesh.Trimesh
     )
 
     return new_mesh
-

--- a/app/core/intervention.py
+++ b/app/core/intervention.py
@@ -34,7 +34,10 @@ def analyze_mesh(mesh: trimesh.Trimesh) -> Dict[str, float | int | bool]:
 
     result["has_holes"] = not mesh.is_watertight
 
-    unique_idx, counts = np.unique(mesh.edges_unique_inverse, return_counts=True)
+    unique_idx, counts = np.unique(
+        mesh.edges_unique_inverse,
+        return_counts=True,
+    )
     isolated_edges = mesh.edges_unique[counts == 1]
     result["isolated_edges"] = int(len(isolated_edges))
 

--- a/app/core/io.py
+++ b/app/core/io.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import trimesh
 
@@ -70,4 +69,3 @@ def save_mesh(mesh: trimesh.Trimesh, path: str) -> None:
         raise IOError(f"Directory does not exist for path: {path}") from None
     except Exception as exc:  # pragma: no cover - rely on trimesh exceptions
         raise IOError(f"Could not write mesh to {path}") from exc
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import subprocess
 import sys
 
-import pytest
 import trimesh
 
 from app.core.io import load_mesh
@@ -30,5 +29,5 @@ def test_cli_cristify(tmp_path):
     assert output_path.exists()
     result = load_mesh(str(output_path))
     assert isinstance(result, trimesh.Trimesh)
-    assert result.vertices[:, 2].min() < trimesh.load(str(input_path)).vertices[:, 2].min()
-
+    original = trimesh.load(str(input_path))
+    assert result.vertices[:, 2].min() < original.vertices[:, 2].min()

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -1,4 +1,3 @@
-import pytest
 import trimesh
 
 from app.core import analyze_mesh

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -29,4 +29,3 @@ def test_save_invalid_directory(tmp_path):
     invalid_path = tmp_path / "no_dir" / "mesh.stl"
     with pytest.raises(IOError):
         save_mesh(mesh, os.fspath(invalid_path))
-

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,4 +1,4 @@
-import pytest
+
 
 def test_dummy():
     assert True


### PR DESCRIPTION
## Summary
- remove the unused `Any` import
- reformat CLI and core modules to satisfy flake8
- clean up tests accordingly

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_b_68430fb53b4c832295a8693120cccaff