### PR TITLE
Add mesh repair utilities and tests

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -2,5 +2,11 @@
 
 from .intervention import analyze_mesh
 from .cristify import cristify_mesh
+from .mesh_utils import repair_mesh, make_watertight
 
-__all__ = ["analyze_mesh", "cristify_mesh"]
+__all__ = [
+    "analyze_mesh",
+    "cristify_mesh",
+    "repair_mesh",
+    "make_watertight",
+]

--- a/app/core/mesh_utils.py
+++ b/app/core/mesh_utils.py
@@ -1,1 +1,68 @@
-"""Mesh utilities placeholder."""
+"""Utility helpers for cleaning and repairing meshes."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+import open3d as o3d
+
+
+def _to_open3d(mesh: trimesh.Trimesh) -> o3d.geometry.TriangleMesh:
+    """Convert a :class:`trimesh.Trimesh` to an Open3D mesh."""
+    vertices = o3d.utility.Vector3dVector(mesh.vertices)
+    triangles = o3d.utility.Vector3iVector(mesh.faces)
+    return o3d.geometry.TriangleMesh(vertices, triangles)
+
+
+def _from_open3d(o3_mesh: o3d.geometry.TriangleMesh) -> trimesh.Trimesh:
+    """Create a :class:`trimesh.Trimesh` from an Open3D mesh."""
+    vertices = np.asarray(o3_mesh.vertices)
+    faces = np.asarray(o3_mesh.triangles)
+    return trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+
+
+def repair_mesh(mesh: trimesh.Trimesh) -> trimesh.Trimesh:
+    """Perform lightweight cleanup of a mesh.
+
+    Operations include removal of degenerate and duplicate faces as well as
+    merging of identical vertices. The original mesh is not modified.
+
+    Parameters
+    ----------
+    mesh:
+        Mesh to repair.
+
+    Returns
+    -------
+    trimesh.Trimesh
+        A new mesh instance with common defects removed.
+    """
+
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise TypeError("mesh must be a trimesh.Trimesh instance")
+
+    o3_mesh = _to_open3d(mesh)
+    o3_mesh.remove_duplicated_vertices()
+    o3_mesh.remove_duplicated_triangles()
+    o3_mesh.remove_degenerate_triangles()
+    o3_mesh.remove_non_manifold_edges()
+    o3_mesh.remove_unreferenced_vertices()
+
+    cleaned = _from_open3d(o3_mesh)
+    cleaned.remove_duplicate_faces()
+    cleaned.remove_degenerate_faces()
+    cleaned.remove_unreferenced_vertices()
+
+    return cleaned
+
+
+def make_watertight(mesh: trimesh.Trimesh) -> trimesh.Trimesh:
+    """Attempt to make a mesh watertight by filling simple holes."""
+
+    repaired = repair_mesh(mesh)
+    trimesh.repair.fill_holes(repaired)
+    repaired.remove_unreferenced_vertices()
+    return repaired
+
+
+__all__ = ["repair_mesh", "make_watertight"]

--- a/tests/test_mesh_utils.py
+++ b/tests/test_mesh_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import trimesh
+
+from app.core.mesh_utils import repair_mesh, make_watertight
+
+
+def test_repair_mesh_removes_degenerate():
+    box = trimesh.creation.box()
+    mesh = box.copy()
+    mesh.faces = np.vstack([mesh.faces, [0, 0, 0]])
+
+    assert len(mesh.faces) == len(box.faces) + 1
+
+    repaired = repair_mesh(mesh)
+
+    assert len(repaired.faces) == len(box.faces)
+    # original mesh unchanged
+    assert len(mesh.faces) == len(box.faces) + 1
+
+
+def test_make_watertight_fills_hole():
+    box = trimesh.creation.box()
+    mesh = box.copy()
+    mesh.faces = mesh.faces[:-1]
+    assert not mesh.is_watertight
+
+    result = make_watertight(mesh)
+    assert result.is_watertight
+    # ensure original mesh unchanged
+    assert not mesh.is_watertight


### PR DESCRIPTION
## Summary
- implement `repair_mesh` and `make_watertight` utilities using Open3D and trimesh
- expose new utilities in `app.core`
- test mesh repairs and hole filling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430fb1dda083228edebdb033e2554d