### PR TITLE
Update CI to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- use Python 3.11 for GitHub Actions workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for packages such as trimesh and numpy)*

------
https://chatgpt.com/codex/tasks/task_b_68433f61be6c8322b85dfbb5c2cb2221