### PR TITLE
Fix README project structure comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Cristify-STL/
       main_gui.py         # Main GUI application
       viewer.py           # 3D visualizer
     assets/               # UI themes, icons
-    data/                 # User STL files                  # User STL files
+    data/                 # User STL files
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix duplicated comment in README project structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_b_68434003465c8322a035d100ab25d554