### PR TITLE
Implement extended cristify options

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -26,6 +26,17 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
         default=1.0,
         help="Cristify amount scale factor",
     )
+    parser.add_argument(
+        "--axis",
+        default="z",
+        help="Axis to project along (x, y, or z)",
+    )
+    parser.add_argument(
+        "--floor",
+        type=float,
+        default=None,
+        help="Optional minimum coordinate after projection",
+    )
     return parser.parse_args(args)
 
 
@@ -33,7 +44,12 @@ def main(args: Sequence[str] | None = None) -> int:
     opts = parse_args(args)
 
     mesh = load_mesh(opts.input)
-    result = cristify_mesh(mesh, amount=opts.amount)
+    result = cristify_mesh(
+        mesh,
+        amount=opts.amount,
+        axis=opts.axis,
+        floor=opts.floor,
+    )
     save_mesh(result, opts.output)
     return 0
 

--- a/app/core/cristify.py
+++ b/app/core/cristify.py
@@ -9,11 +9,15 @@ import trimesh
 def cristify_mesh(
     mesh: trimesh.Trimesh,
     amount: float = 1.0,
+    *,
+    axis: int | str = 2,
+    floor: float | None = None,
 ) -> trimesh.Trimesh:
     """Project vertices downward to create a draped effect.
 
-    Each vertex is translated along the negative ``Z`` axis by ``amount`` times
-    its distance from the top of the mesh. The original mesh is not modified.
+    Each vertex is translated along the negative chosen axis by ``amount``
+    times its distance from the top of the mesh. The original mesh is not
+    modified.
 
     Parameters
     ----------
@@ -23,6 +27,12 @@ def cristify_mesh(
         Scale factor for the downward displacement. ``1.0`` moves each
         vertex by its full distance from the top, ``0`` leaves the mesh
         unchanged.
+    axis:
+        Axis to project along. Can be ``0``, ``1``, ``2`` or ``"x"``, ``"y``,
+        ``"z"``. Default is the Z axis.
+    floor:
+        Optional minimum coordinate value. Vertices will not be moved below
+        this value after projection.
 
     Returns
     -------
@@ -36,14 +46,29 @@ def cristify_mesh(
     if not np.isscalar(amount):
         raise TypeError("amount must be a scalar numeric value")
 
+    if isinstance(axis, str):
+        axis_map = {"x": 0, "y": 1, "z": 2}
+        if axis.lower() not in axis_map:
+            raise ValueError("axis must be 0, 1, 2 or 'x', 'y', 'z'")
+        axis_index = axis_map[axis.lower()]
+    elif axis in (0, 1, 2):
+        axis_index = int(axis)
+    else:
+        raise ValueError("axis must be 0, 1, 2 or 'x', 'y', 'z'")
+
     vertices = mesh.vertices.view(np.ndarray)
     faces = mesh.faces.view(np.ndarray)
 
-    max_z = float(vertices[:, 2].max()) if len(vertices) else 0.0
+    max_axis = float(vertices[:, axis_index].max()) if len(vertices) else 0.0
 
     new_vertices = vertices.copy()
-    distances = max_z - vertices[:, 2]
-    new_vertices[:, 2] -= distances * float(amount)
+    distances = max_axis - vertices[:, axis_index]
+    new_vertices[:, axis_index] -= distances * float(amount)
+    if floor is not None:
+        new_vertices[:, axis_index] = np.maximum(
+            new_vertices[:, axis_index],
+            floor,
+        )
 
     new_mesh = trimesh.Trimesh(
         vertices=new_vertices,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,8 @@ def test_cli_cristify(tmp_path):
             str(output_path),
             "--amount",
             "0.5",
+            "--axis",
+            "z",
         ]
     )
 
@@ -31,3 +33,31 @@ def test_cli_cristify(tmp_path):
     assert isinstance(result, trimesh.Trimesh)
     original = trimesh.load(str(input_path))
     assert result.vertices[:, 2].min() < original.vertices[:, 2].min()
+
+
+def test_cli_axis_option(tmp_path):
+    input_path = tmp_path / "in2.stl"
+    output_path = tmp_path / "out2.stl"
+
+    trimesh.primitives.Box().export(input_path)
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "app.cli",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--amount",
+            "1.0",
+            "--axis",
+            "y",
+        ]
+    )
+
+    assert output_path.exists()
+    result = load_mesh(str(output_path))
+    original = trimesh.load(str(input_path))
+    assert result.vertices[:, 1].min() < original.vertices[:, 1].min()

--- a/tests/test_cristify.py
+++ b/tests/test_cristify.py
@@ -29,3 +29,22 @@ def test_cristify_zero_amount():
     mesh = trimesh.primitives.Box(extents=(1, 1, 1))
     result = cristify_mesh(mesh, amount=0.0)
     assert np.allclose(mesh.vertices, result.vertices)
+
+
+def test_cristify_axis_y():
+    mesh = trimesh.primitives.Box(extents=(1, 1, 1))
+    original_min_y = mesh.vertices[:, 1].min()
+    original_max_y = mesh.vertices[:, 1].max()
+
+    result = cristify_mesh(mesh, amount=1.0, axis="y")
+
+    assert result.vertices[:, 1].max() == pytest.approx(original_max_y)
+    expected_min = original_min_y - (original_max_y - original_min_y)
+    assert result.vertices[:, 1].min() == pytest.approx(expected_min)
+
+
+def test_cristify_with_floor():
+    mesh = trimesh.primitives.Box(extents=(1, 1, 1))
+    floor = -0.25
+    result = cristify_mesh(mesh, amount=1.0, floor=floor)
+    assert result.vertices[:, 2].min() >= floor


### PR DESCRIPTION
## Summary
- allow cristify_mesh to project along any axis and clamp to a floor
- expose the axis and floor options through CLI
- test new parameters in library and CLI

## Testing
- `flake8 app/core/cristify.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6843795f8c688322b808430644d47b80