### PR TITLE
Add axis choices and validate CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -29,6 +29,7 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--axis",
         default="z",
+        choices=["x", "y", "z"],
         help="Axis to project along (x, y, or z)",
     )
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,10 @@
 import subprocess
 import sys
 
+import pytest
+
+from app.cli import parse_args
+
 import trimesh
 
 from app.core.io import load_mesh
@@ -61,3 +65,22 @@ def test_cli_axis_option(tmp_path):
     result = load_mesh(str(output_path))
     original = trimesh.load(str(input_path))
     assert result.vertices[:, 1].min() < original.vertices[:, 1].min()
+
+
+def test_cli_invalid_axis(tmp_path):
+    input_path = tmp_path / "in3.stl"
+    output_path = tmp_path / "out3.stl"
+
+    trimesh.primitives.Box().export(input_path)
+
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--axis",
+                "invalid",
+            ]
+        )


### PR DESCRIPTION
## Summary
- restrict `--axis` option in CLI to x/y/z
- verify invalid axis is rejected in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68438771193c832299193162e6a02f38