### PR TITLE
Add texturize and gravity utilities

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,7 +9,6 @@ from app.core.io import load_mesh, save_mesh
 from app.core.cristify import cristify_mesh
 from app.core.mesh_utils import repair_mesh, make_watertight
 from app.core import analyze_mesh
-from app.voronizer import PipelineConfig, run_pipeline
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -54,6 +53,8 @@ def main(args: Sequence[str] | None = None) -> int:
         result = cristify_mesh(mesh, amount=opts.amount, axis=opts.axis, floor=opts.floor)
         save_mesh(result, opts.output)
     elif opts.command == "voronize":
+        from app.voronizer import PipelineConfig, run_pipeline  # lazy import
+
         config = PipelineConfig(
             FILE_NAME=opts.file_name,
             PRIMITIVE_TYPE=opts.primitive_type,

--- a/app/core/gravity.py
+++ b/app/core/gravity.py
@@ -1,0 +1,31 @@
+"""Utilities for mesh deformation using a gravity/tension model."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+from scipy.spatial import KDTree
+
+
+def apply_gravitational_tension_model(
+    input_mesh: trimesh.Trimesh,
+    kd_tree: KDTree,
+    g: float = 1e-3,
+    tension: float = 0.1,
+) -> np.ndarray:
+    """Apply gravitational attraction with a simple tension component."""
+    new_vertices = input_mesh.vertices.copy()
+    k = min(10, len(input_mesh.vertices))
+    for i, vertex in enumerate(input_mesh.vertices):
+        distances, indices = kd_tree.query(vertex, k=k)
+        force = np.zeros(3)
+        for dist, index in zip(distances[1:], indices[1:]):
+            direction = input_mesh.vertices[index] - vertex
+            if dist > 0:
+                force += g * direction / (dist ** 2)
+        tension_force = tension * np.sum(new_vertices, axis=0) / len(new_vertices)
+        new_vertices[i] += force - tension_force
+    return new_vertices
+
+
+__all__ = ["apply_gravitational_tension_model"]

--- a/app/core/texturize.py
+++ b/app/core/texturize.py
@@ -1,0 +1,80 @@
+"""Utilities for procedurally texturizing meshes."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+from scipy.spatial import KDTree
+
+
+def create_kd_tree(vertices: np.ndarray) -> KDTree:
+    """Return a :class:`KDTree` built from ``vertices``."""
+    if not isinstance(vertices, np.ndarray):
+        raise ValueError("vertices must be a numpy array")
+    return KDTree(vertices)
+
+
+def apply_gravitational_attraction(
+    input_mesh: trimesh.Trimesh,
+    kd_tree: KDTree,
+    g: float = 1e-3,
+) -> np.ndarray:
+    """Apply a simple gravitational attraction among neighbouring vertices."""
+    new_vertices = input_mesh.vertices.copy()
+    k = min(10, len(input_mesh.vertices))
+    for i, vertex in enumerate(input_mesh.vertices):
+        distances, indices = kd_tree.query(vertex, k=k)
+        force = np.zeros(3)
+        for dist, index in zip(distances[1:], indices[1:]):
+            direction = input_mesh.vertices[index] - vertex
+            if dist > 0:
+                force += g * direction / (dist ** 2)
+        new_vertices[i] += force
+    return new_vertices
+
+
+def fractal_noise(vertices: np.ndarray, scale: float = 0.1, octaves: int = 4) -> np.ndarray:
+    """Add fractal noise to ``vertices``."""
+    if not isinstance(vertices, np.ndarray):
+        raise ValueError("vertices must be a numpy array")
+    noise = np.zeros_like(vertices)
+    for octave in range(octaves):
+        frequency = 2 ** octave
+        amplitude = scale / frequency
+        noise += amplitude * np.random.randn(*vertices.shape)
+    return vertices + noise
+
+
+def smooth_mesh(mesh: trimesh.Trimesh, iterations: int = 100) -> trimesh.Trimesh:
+    """Run Taubin smoothing on ``mesh``."""
+    working = trimesh.Trimesh(
+        vertices=mesh.vertices.copy(), faces=mesh.faces.copy(), process=False
+    )
+    trimesh.smoothing.filter_taubin(working, iterations=iterations)
+    return working
+
+
+def make_organic_with_gravity(
+    input_mesh: trimesh.Trimesh,
+    noise_strength: float = 0.01,
+    smooth_iterations: int = 200,
+    g: float = 1e-3,
+) -> trimesh.Trimesh:
+    """Blend noise, smoothing and gravitational attraction."""
+    noise = noise_strength * np.random.randn(*input_mesh.vertices.shape)
+    input_mesh.vertices += noise
+    trimesh.smoothing.filter_taubin(
+        input_mesh, lamb=0.5, nu=-0.53, iterations=smooth_iterations
+    )
+    kd_tree = create_kd_tree(input_mesh.vertices)
+    input_mesh.vertices = apply_gravitational_attraction(input_mesh, kd_tree, g)
+    return input_mesh
+
+
+__all__ = [
+    "create_kd_tree",
+    "apply_gravitational_attraction",
+    "fractal_noise",
+    "smooth_mesh",
+    "make_organic_with_gravity",
+]

--- a/tests/test_gravity.py
+++ b/tests/test_gravity.py
@@ -1,0 +1,13 @@
+import numpy as np
+import trimesh
+
+from app.core.texturize import create_kd_tree
+from app.core.gravity import apply_gravitational_tension_model
+
+
+def test_apply_gravitational_tension_model():
+    mesh = trimesh.primitives.Box()
+    kd = create_kd_tree(mesh.vertices)
+    new_verts = apply_gravitational_tension_model(mesh, kd, g=1e-2, tension=0.1)
+    assert new_verts.shape == mesh.vertices.shape
+    assert not np.allclose(new_verts, mesh.vertices)

--- a/tests/test_texturize.py
+++ b/tests/test_texturize.py
@@ -1,0 +1,39 @@
+import numpy as np
+import trimesh
+
+from app.core.texturize import (
+    create_kd_tree,
+    apply_gravitational_attraction,
+    fractal_noise,
+    smooth_mesh,
+)
+
+
+def test_create_kd_tree():
+    vertices = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    tree = create_kd_tree(vertices)
+    dist, idx = tree.query([0.0, 0.0, 0.0], k=1)
+    assert idx == 0
+    assert np.isclose(dist, 0.0)
+
+
+def test_apply_gravitational_attraction():
+    mesh = trimesh.primitives.Box()
+    kd = create_kd_tree(mesh.vertices)
+    result = apply_gravitational_attraction(mesh, kd, g=1e-2)
+    assert result.shape == mesh.vertices.shape
+    assert not np.allclose(result, mesh.vertices)
+
+
+def test_fractal_noise():
+    verts = np.zeros((5, 3))
+    noisy = fractal_noise(verts, scale=0.5, octaves=2)
+    assert noisy.shape == verts.shape
+    assert not np.allclose(noisy, verts)
+
+
+def test_smooth_mesh():
+    mesh = trimesh.primitives.Box()
+    result = smooth_mesh(mesh.copy(), iterations=1)
+    assert isinstance(result, trimesh.Trimesh)
+    assert result.vertices.shape == mesh.vertices.shape


### PR DESCRIPTION
## Summary
- add `texturize` helpers with KDTree, gravitational attraction, noise, and smoothing
- add `gravity` module with gravitational tension model
- make `app.cli` lazily import Voronizer to avoid heavy deps
- test new utilities with simple meshes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f0638a9f48322b017c41a867bc733