### PR TITLE
Add mesh gaudify, wrap and simplify utilities

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -3,10 +3,24 @@
 from .intervention import analyze_mesh
 from .cristify import cristify_mesh
 from .mesh_utils import repair_mesh, make_watertight
+from .gaudify import (
+    get_overhang_faces,
+    modify_overhangs,
+    gaudify_mesh,
+    reorient_mesh_for_printing,
+)
+from .wrap import wrap_mesh
+from .simplify import simplify_mesh
 
 __all__ = [
     "analyze_mesh",
     "cristify_mesh",
     "repair_mesh",
     "make_watertight",
+    "gaudify_mesh",
+    "get_overhang_faces",
+    "modify_overhangs",
+    "reorient_mesh_for_printing",
+    "wrap_mesh",
+    "simplify_mesh",
 ]

--- a/app/core/gaudify.py
+++ b/app/core/gaudify.py
@@ -1,0 +1,99 @@
+"""Utilities for Gaudification of meshes.
+
+This module provides simple heuristics for transforming a mesh to
+reduce overhangs by converting them into gothic-like arches.
+The implementation is adapted from the experimental ``scripts/3.py`` file.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import numpy as np
+import trimesh
+
+
+def reorient_mesh_for_printing(mesh: trimesh.Trimesh) -> trimesh.Trimesh:
+    """Orient ``mesh`` using its oriented bounding box."""
+    mesh = mesh.copy()
+    mesh.rezero()
+    orientation = mesh.bounding_box_oriented.primitive.transform
+    mesh.apply_transform(orientation)
+    return mesh
+
+
+def get_overhang_faces(input_mesh: trimesh.Trimesh, max_overhang_angle: float = 45.0) -> np.ndarray:
+    """Return indices of faces exceeding ``max_overhang_angle`` from vertical."""
+    angles = input_mesh.face_normals[:, 2]
+    overhang_faces = np.where(np.degrees(np.arccos(angles)) > max_overhang_angle)[0]
+    return overhang_faces
+
+
+def modify_overhangs(input_mesh: trimesh.Trimesh, overhang_faces: Iterable[int]) -> trimesh.Trimesh:
+    """Replace ``overhang_faces`` with simple gothic arch structures."""
+    mesh = input_mesh.copy()
+    new_faces: list[list[int]] = []
+    new_vertices_list: list[np.ndarray] = []
+
+    for face_index in overhang_faces:
+        face = mesh.faces[face_index]
+        vertices = mesh.vertices[face]
+
+        center = vertices.mean(axis=0)
+        center[2] += 0.01
+
+        new_vertex_indices = []
+        for _ in range(3):
+            new_vertices_list.append(center)
+            new_vertex_indices.append(len(mesh.vertices) + len(new_vertices_list) - 1)
+
+        for i in range(3):
+            new_faces.append([face[i], face[(i + 1) % 3], new_vertex_indices[i]])
+
+    if new_vertices_list:
+        new_vertices_array = np.array(new_vertices_list)
+        mesh.vertices = np.vstack((mesh.vertices, new_vertices_array))
+
+    # remove original overhang faces then append new ones
+    remaining = np.delete(mesh.faces, list(overhang_faces), axis=0)
+    if new_faces:
+        new_faces_array = np.array(new_faces)
+        mesh.faces = np.vstack((remaining, new_faces_array))
+    else:
+        mesh.faces = remaining
+
+    return mesh
+
+
+def gaudify_mesh(
+    input_mesh: trimesh.Trimesh,
+    max_overhang_angle: float = 45.0,
+    max_iterations: int = 10,
+) -> trimesh.Trimesh:
+    """Iteratively modify overhangs until none remain or ``max_iterations`` is reached."""
+    mesh = input_mesh.copy()
+    iteration = 0
+
+    while iteration < max_iterations:
+        overhang_faces = get_overhang_faces(mesh, max_overhang_angle)
+        if len(overhang_faces) == 0:
+            break
+        mesh = modify_overhangs(mesh, overhang_faces)
+        iteration += 1
+        if not mesh.is_watertight:
+            logging.warning(
+                "Mesh is not watertight after modification; continuing without repair"
+            )
+        if mesh.faces.shape[0] == 0:
+            logging.error("Mesh has no faces after modification; stopping")
+            break
+    return mesh
+
+
+__all__ = [
+    "reorient_mesh_for_printing",
+    "get_overhang_faces",
+    "modify_overhangs",
+    "gaudify_mesh",
+]

--- a/app/core/simplify.py
+++ b/app/core/simplify.py
@@ -1,0 +1,33 @@
+"""Mesh simplification helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+import open3d as o3d
+
+
+def simplify_mesh(mesh: trimesh.Trimesh, target_reduction: float = 0.5) -> trimesh.Trimesh:
+    """Return a simplified copy of ``mesh`` using quadric decimation."""
+    if not (0.0 < target_reduction < 1.0):
+        raise ValueError("target_reduction must be between 0 and 1")
+
+    target_faces = max(4, int(len(mesh.faces) * (1 - target_reduction)))
+
+    o3_mesh = o3d.geometry.TriangleMesh(
+        o3d.utility.Vector3dVector(mesh.vertices),
+        o3d.utility.Vector3iVector(mesh.faces),
+    )
+    simplified = o3_mesh.simplify_quadric_decimation(target_faces)
+    simplified.remove_degenerate_triangles()
+    simplified.remove_duplicated_triangles()
+    simplified.remove_duplicated_vertices()
+    simplified.remove_non_manifold_edges()
+    simplified.remove_unreferenced_vertices()
+
+    vertices = np.asarray(simplified.vertices)
+    faces = np.asarray(simplified.triangles)
+    return trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+
+
+__all__ = ["simplify_mesh"]

--- a/app/core/wrap.py
+++ b/app/core/wrap.py
@@ -1,0 +1,31 @@
+"""Basic mesh wrapping utility."""
+
+from __future__ import annotations
+
+import numpy as np
+import trimesh
+
+
+def wrap_mesh(input_mesh: trimesh.Trimesh, wrap_thickness: float = 0.1) -> trimesh.Trimesh:
+    """Return a copy of ``input_mesh`` with vertices offset along normals.
+
+    Parameters
+    ----------
+    input_mesh:
+        Mesh to wrap.
+    wrap_thickness:
+        Distance to offset each vertex along its normal.
+    """
+    if wrap_thickness <= 0:
+        raise ValueError("wrap_thickness must be positive")
+
+    mesh = input_mesh.copy()
+    normals = mesh.vertex_normals
+    if normals.shape[0] == 0:
+        mesh.compute_vertex_normals()
+        normals = mesh.vertex_normals
+    mesh.vertices = mesh.vertices + wrap_thickness * normals
+    return mesh
+
+
+__all__ = ["wrap_mesh"]

--- a/tests/test_new_ops.py
+++ b/tests/test_new_ops.py
@@ -1,0 +1,84 @@
+import subprocess
+import sys
+import trimesh
+import numpy as np
+
+from app.core.gaudify import gaudify_mesh
+from app.core.wrap import wrap_mesh
+from app.core.simplify import simplify_mesh
+from app.core.io import load_mesh
+
+
+def test_gaudify_function():
+    mesh = trimesh.creation.box()
+    result = gaudify_mesh(mesh, max_overhang_angle=45.0, max_iterations=1)
+    assert isinstance(result, trimesh.Trimesh)
+    assert len(result.faces) >= len(mesh.faces)
+
+
+def test_wrap_function():
+    mesh = trimesh.creation.box()
+    wrapped = wrap_mesh(mesh, wrap_thickness=0.05)
+    assert not np.allclose(wrapped.vertices, mesh.vertices)
+    assert wrapped.faces.shape == mesh.faces.shape
+
+
+def test_simplify_function():
+    mesh = trimesh.creation.icosphere(subdivisions=2)
+    simplified = simplify_mesh(mesh, target_reduction=0.5)
+    assert simplified.faces.shape[0] < mesh.faces.shape[0]
+
+
+def test_cli_gaudify(tmp_path):
+    input_path = tmp_path / "g_in.stl"
+    output_path = tmp_path / "g_out.stl"
+    trimesh.creation.box().export(input_path)
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "app.cli",
+        "gaudify",
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+    ])
+    assert output_path.exists()
+    result = load_mesh(str(output_path))
+    assert isinstance(result, trimesh.Trimesh)
+
+
+def test_cli_wrap(tmp_path):
+    input_path = tmp_path / "w_in.stl"
+    output_path = tmp_path / "w_out.stl"
+    trimesh.creation.box().export(input_path)
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "app.cli",
+        "wrap",
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+    ])
+    assert output_path.exists()
+
+
+def test_cli_simplify(tmp_path):
+    input_path = tmp_path / "s_in.stl"
+    output_path = tmp_path / "s_out.stl"
+    trimesh.creation.icosphere().export(input_path)
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "app.cli",
+        "simplify",
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+        "--reduction",
+        "0.5",
+    ])
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- add new `gaudify`, `wrap`, `simplify` modules
- expose new functions in `app.core`
- extend CLI with `gaudify`, `wrap`, and `simplify` commands
- provide tests for new operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f08c8313c832291805206c21f1d78