### PR TITLE
Integrate missing fractal and repair utilities

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -2,7 +2,8 @@
 
 from .intervention import analyze_mesh
 from .cristify import cristify_mesh
-from .mesh_utils import repair_mesh, make_watertight
+from .mesh_utils import repair_mesh, make_watertight, repair_until_watertight
+from .fractal import generate_fractal_geometry
 from .gaudify import (
     get_overhang_faces,
     modify_overhangs,
@@ -17,6 +18,8 @@ __all__ = [
     "cristify_mesh",
     "repair_mesh",
     "make_watertight",
+    "repair_until_watertight",
+    "generate_fractal_geometry",
     "gaudify_mesh",
     "get_overhang_faces",
     "modify_overhangs",

--- a/app/core/fractal.py
+++ b/app/core/fractal.py
@@ -1,0 +1,53 @@
+"""Fractal geometry utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+
+
+def generate_fractal_geometry(
+    vertices: np.ndarray,
+    edges: Iterable[Sequence[int]],
+    iterations: int = 1,
+) -> Tuple[np.ndarray, list[Tuple[int, int]]]:
+    """Iteratively insert midpoints for each edge.
+
+    Parameters
+    ----------
+    vertices:
+        Array of vertex coordinates.
+    edges:
+        Iterable of edges defined by pairs of vertex indices.
+    iterations:
+        Number of subdivision passes to run.
+
+    Returns
+    -------
+    numpy.ndarray
+        The new array of vertices containing any newly added points.
+    list of tuple[int, int]
+        The original ``edges`` as a list of pairs.
+    """
+
+    if not isinstance(vertices, np.ndarray):
+        raise TypeError("vertices must be a numpy array")
+
+    edge_pairs = [tuple(map(int, e)) for e in edges]
+    new_vertices = vertices.astype(float).tolist()
+
+    for _ in range(iterations):
+        edge_to_new = {}
+        for edge in edge_pairs:
+            ordered = tuple(sorted(edge))
+            if ordered not in edge_to_new:
+                midpoint = (vertices[ordered[0]] + vertices[ordered[1]]) / 2.0
+                edge_to_new[ordered] = len(new_vertices)
+                new_vertices.append(midpoint)
+        vertices = np.asarray(new_vertices, dtype=float)
+
+    return np.asarray(new_vertices, dtype=float), edge_pairs
+
+
+__all__ = ["generate_fractal_geometry"]

--- a/scripts/optimizacion_fractal.py
+++ b/scripts/optimizacion_fractal.py
@@ -1,15 +1,10 @@
+"""Example usage of :func:`app.core.fractal.generate_fractal_geometry`."""
+
 import numpy as np
+from app.core.fractal import generate_fractal_geometry
 
-def generate_fractal_geometry(vertices, edges, iterations=1):
-    new_vertices = vertices.tolist()
-    for _ in range(iterations):
-        edge_to_new_vertex = {}
-        for edge in edges:
-            edge = tuple(sorted(edge))
-            if edge not in edge_to_new_vertex:
-                midpoint = (vertices[edge[0]] + vertices[edge[1]]) / 2.0
-                new_vertex_index = len(new_vertices)
-                new_vertices.append(midpoint)
-                edge_to_new_vertex[edge] = new_vertex_index
-
-    return np.array(new_vertices), edges
+if __name__ == "__main__":
+    verts = np.array([[0, 0, 0], [1, 0, 0]])
+    edges = [(0, 1)]
+    new_verts, _ = generate_fractal_geometry(verts, edges, iterations=1)
+    print(new_verts)

--- a/scripts/repair_mesh.py
+++ b/scripts/repair_mesh.py
@@ -1,42 +1,11 @@
+"""Example invoking :func:`app.core.mesh_utils.repair_until_watertight`."""
+
 import trimesh
-import time
-import logging
+from app.core.mesh_utils import repair_until_watertight
 
-def repair_mesh(mesh: trimesh.Trimesh, max_time_seconds: int = 300) -> trimesh.Trimesh:
-    initial_vertex_count = len(mesh.vertices)
-    initial_triangle_count = len(mesh.faces)
-
-    start_time = time.time()
-    iteration = 0
-
-    while time.time() - start_time < max_time_seconds:
-        iteration += 1
-        # Reparaciones de la malla
-        mesh.fill_holes()
-        mesh.remove_degenerate_faces()
-        mesh.remove_duplicate_faces()
-        mesh.remove_infinite_values()
-        mesh.remove_unreferenced_vertices()
-        mesh.process(validate=True)
-
-        final_vertex_count = len(mesh.vertices)
-        final_triangle_count = len(mesh.faces)
-
-        logging.info(f"Iteration {iteration}: Vertex count changes from {initial_vertex_count} to {final_vertex_count} ({final_vertex_count - initial_vertex_count:+d})")
-        logging.info(f"Iteration {iteration}: Triangle count changes from {initial_triangle_count} to {final_triangle_count} ({final_triangle_count - initial_triangle_count:+d})")
-
-        if mesh.is_watertight:
-            logging.info("Malla reparada y es watertight.")
-            return mesh
-        else:
-            logging.warning(f"Reparación iteración {iteration} no fue exitosa. Intentando nuevamente...")
-
-    logging.error("La malla no se pudo reparar para ser watertight después del tiempo máximo permitido.")
-    report_mesh_problems(mesh)
-    return mesh
-
-def report_mesh_problems(mesh: trimesh.Trimesh) -> None:
-    if not mesh.is_watertight:
-        logging.warning("La malla tiene agujeros.")
-    if not mesh.is_watertight:
-        logging.warning("La malla tiene bordes no conectados.")
+if __name__ == "__main__":
+    mesh = trimesh.creation.box()
+    broken = mesh.copy()
+    broken.faces = broken.faces[:-1]
+    fixed = repair_until_watertight(broken, max_time_seconds=1)
+    print(f"Watertight: {fixed.is_watertight}")

--- a/tests/test_fractal.py
+++ b/tests/test_fractal.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from app.core.fractal import generate_fractal_geometry
+
+
+def test_generate_fractal_geometry_single_iteration():
+    verts = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    edges = [(0, 1), (1, 2), (2, 3), (3, 0)]
+    new_v, new_e = generate_fractal_geometry(verts, edges, iterations=1)
+    assert new_v.shape[0] == 8
+    mid = (verts[0] + verts[1]) / 2.0
+    assert any(np.allclose(mid, v) for v in new_v[4:])
+    assert new_e == edges
+
+
+def test_generate_fractal_geometry_multiple_iterations():
+    verts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    edges = [(0, 1)]
+    new_v, _ = generate_fractal_geometry(verts, edges, iterations=2)
+    assert new_v.shape[0] == 4

--- a/tests/test_mesh_utils.py
+++ b/tests/test_mesh_utils.py
@@ -1,7 +1,11 @@
 import numpy as np
 import trimesh
 
-from app.core.mesh_utils import repair_mesh, make_watertight
+from app.core.mesh_utils import (
+    repair_mesh,
+    make_watertight,
+    repair_until_watertight,
+)
 
 
 def test_repair_mesh_removes_degenerate():
@@ -27,4 +31,14 @@ def test_make_watertight_fills_hole():
     result = make_watertight(mesh)
     assert result.is_watertight
     # ensure original mesh unchanged
+    assert not mesh.is_watertight
+
+def test_repair_until_watertight():
+    box = trimesh.creation.box()
+    mesh = box.copy()
+    mesh.faces = mesh.faces[:-1]
+    assert not mesh.is_watertight
+
+    result = repair_until_watertight(mesh, max_time_seconds=1)
+    assert result.is_watertight
     assert not mesh.is_watertight


### PR DESCRIPTION
## Summary
- port fractal geometry helper from old scripts
- add iterative mesh repair util
- expose new helpers from core package
- update example scripts to use the new API
- test the new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f17e0945883229b028f359ccff058