### PR TITLE
Add numba to requirements.txt to fix CI test collection failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.26.4
 scipy==1.15.3
 dearpygui==1.11.1
 networkx==3.5
+numba


### PR DESCRIPTION
The test suite imports app/voronizer/Frep.py which depends on numba.cuda, but numba was missing from requirements.txt causing pytest to fail during collection in CI.

https://claude.ai/code/session_01FvKp6PVsborJuvjDpP72qE