### PR TITLE
Replace deprecated trimesh face cleaning methods with update_faces

### DIFF
--- a/app/core/mesh_utils.py
+++ b/app/core/mesh_utils.py
@@ -50,8 +50,8 @@ def repair_mesh(mesh: trimesh.Trimesh) -> trimesh.Trimesh:
     o3_mesh.remove_unreferenced_vertices()
 
     cleaned = _from_open3d(o3_mesh)
-    cleaned.remove_duplicate_faces()
-    cleaned.remove_degenerate_faces()
+    cleaned.update_faces(cleaned.unique_faces())
+    cleaned.update_faces(cleaned.nondegenerate_faces())
     cleaned.remove_unreferenced_vertices()
 
     return cleaned
@@ -75,7 +75,7 @@ def repair_until_watertight(
     start = time.time()
     while time.time() - start < max_time_seconds:
         working.fill_holes()
-        working.remove_degenerate_faces()
+        working.update_faces(working.nondegenerate_faces())
         working.update_faces(working.unique_faces())
         working.remove_infinite_values()
         working.remove_unreferenced_vertices()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "scipy==1.15.3",
     "dearpygui==1.11.1",
     "networkx==3.5",
+    "numba",
     "scikit-image",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "scipy==1.15.3",
     "dearpygui==1.11.1",
     "networkx==3.5",
+    "scikit-image",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy==1.15.3
 dearpygui==1.11.1
 networkx==3.5
 numba
+scikit-image


### PR DESCRIPTION
## Summary
Updated mesh repair utilities to use the current trimesh API by replacing deprecated face cleaning methods with the `update_faces()` method combined with face filtering functions.

## Key Changes
- Replaced `remove_duplicate_faces()` with `update_faces(unique_faces())` in `repair_mesh()`
- Replaced `remove_degenerate_faces()` with `update_faces(nondegenerate_faces())` in both `repair_mesh()` and `repair_until_watertight()`
- Added scikit-image as a dependency in both `pyproject.toml` and `requirements.txt`

## Implementation Details
The changes modernize the mesh cleaning pipeline to use trimesh's current API pattern. Instead of calling removal methods directly on the mesh object, the code now:
1. Calls the filtering methods (`unique_faces()`, `nondegenerate_faces()`) which return indices of valid faces
2. Passes these indices to `update_faces()` to update the mesh with only the valid faces

This approach is more explicit and aligns with trimesh's current recommended practices for face manipulation.

https://claude.ai/code/session_011hK14qH58ybksMu5Mh9B3o