### PR TITLE
Add CPU fallback for the voronizer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ python -m app.cli cristify --input INPUT.stl --output OUTPUT.stl
 
 # Voronize a model
 python -m app.cli voronize --file-name model.stl --model
+# Voronize uses CUDA when an NVIDIA GPU is available and otherwise falls
+# back to a NumPy/SciPy implementation (e.g. on Apple Silicon). Set
+# CRISTIFY_FORCE_CPU=1 to force the CPU backend.
 
 # Repair a mesh
 python -m app.cli repair --input INPUT.stl --output fixed.stl

--- a/app/voronizer/Frep.py
+++ b/app/voronizer/Frep.py
@@ -2,6 +2,9 @@ from numba import cuda
 import numpy as np
 import math
 
+from . import cpu_ops
+from .backend import cuda_available
+
 
 @cuda.jit
 def smoothKernel(d_u, d_v, buffer):
@@ -39,6 +42,8 @@ def smooth(u, iteration=1, buffer=0, tpb=8):
     numpy.ndarray
         Smoothed voxel grid.
     """
+    if not cuda_available():
+        return cpu_ops.smooth(u, iteration, buffer)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     dims = u.shape
     d_u = cuda.to_device(u)
@@ -73,6 +78,8 @@ def union(u, v, tpb=8):
     numpy.ndarray
         Combined voxel model.
     """
+    if not cuda_available():
+        return cpu_ops.union(u, v)
     d_u = cuda.to_device(u)
     d_v = cuda.to_device(v)
     dims = u.shape
@@ -96,6 +103,8 @@ def intersection(u, v, tpb=8):
     numpy.ndarray
         Voxel model containing only overlapping cells.
     """
+    if not cuda_available():
+        return cpu_ops.intersection(u, v)
     d_u = cuda.to_device(-1 * u)
     d_v = cuda.to_device(-1 * v)
     dims = u.shape
@@ -119,6 +128,8 @@ def subtract(u, v, tpb=8):
     numpy.ndarray
         Resulting voxel grid.
     """
+    if not cuda_available():
+        return cpu_ops.subtract(u, v)
     d_u = cuda.to_device(u)
     d_v = cuda.to_device(-1 * v)
     dims = u.shape
@@ -150,6 +161,8 @@ def projection(u, tpb=8):
     numpy.ndarray
         Projected voxel model.
     """
+    if not cuda_available():
+        return cpu_ops.projection(u)
     TPBY, TPBZ = tpb, tpb
     m, n, p = u.shape
     minX = -1
@@ -193,6 +206,8 @@ def translate(u, x, y, z, tpb=8):
     numpy.ndarray
         Translated voxel grid.
     """
+    if not cuda_available():
+        return cpu_ops.translate(u, x, y, z)
     d_u = cuda.to_device(u)
     d_v = cuda.device_array(shape=u.shape, dtype=np.float32)
     dims = u.shape
@@ -233,6 +248,8 @@ def condense(u, buffer, tpb=8):
     numpy.ndarray
         Condensed voxel grid.
     """
+    if not cuda_available():
+        return cpu_ops.condense(u, buffer, tpb)
     m, n, p = u.shape
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     minX, maxX, minY, maxY, minZ, maxZ = -1,-1,-1,-1,-1,-1
@@ -293,6 +310,8 @@ def heart(x, y, z, cx, cy, cz, tpb=8):
     numpy.ndarray
         Signed distance field of the heart.
     """
+    if not cuda_available():
+        return cpu_ops.heart(x, y, z, cx, cy, cz)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]
@@ -333,6 +352,8 @@ def egg(x, y, z, cx, cy, cz, tpb=8):
     numpy.ndarray
         Signed distance field of the egg.
     """
+    if not cuda_available():
+        return cpu_ops.egg(x, y, z, cx, cy, cz)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]
@@ -375,6 +396,8 @@ def rect(x, y, z, xl, yl, zl, origin=(0, 0, 0), tpb=8):
     numpy.ndarray
         Signed distance field of the prism.
     """
+    if not cuda_available():
+        return cpu_ops.rect(x, y, z, xl, yl, zl, origin)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]
@@ -413,6 +436,8 @@ def sphere(x, y, z, rad, tpb=8):
     numpy.ndarray
         Signed distance field of the sphere.
     """
+    if not cuda_available():
+        return cpu_ops.sphere(x, y, z, rad)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]
@@ -454,6 +479,8 @@ def cylinderX(x, y, z, start, stop, rad, tpb=8):
     numpy.ndarray
         Signed distance field of the cylinder.
     """
+    if not cuda_available():
+        return cpu_ops.cylinderX(x, y, z, start, stop, rad)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]
@@ -495,6 +522,8 @@ def cylinderY(x, y, z, start, stop, rad, tpb=8):
     numpy.ndarray
         Signed distance field of the cylinder.
     """
+    if not cuda_available():
+        return cpu_ops.cylinderY(x, y, z, start, stop, rad)
     TPBX, TPBY, TPBZ = tpb, tpb, tpb
     m = x.shape[0]
     n = y.shape[0]

--- a/app/voronizer/SDF3D.py
+++ b/app/voronizer/SDF3D.py
@@ -2,6 +2,9 @@ from numba import cuda
 import math
 import numpy as np
 
+from . import cpu_ops
+from .backend import cuda_available
+
 @cuda.jit(device = True)
 def norm(i,j,k,m,n,p,order):
     return (abs((i-m)**order)+abs((j-n)**order)+abs((k-p)**order))**(1/order)
@@ -73,6 +76,8 @@ def jumpFlood(u, norm, tpb=8):
     numpy.ndarray
         Jump flood result ``(x, y, z, dist)`` for each cell.
     """
+    if not cuda_available():
+        return cpu_ops.jumpFlood(u, norm)
     dims = u.shape
     gridSize = [(dims[0] + tpb - 1) // tpb, (dims[1] + tpb - 1) // tpb, (dims[2] + tpb - 1) // tpb]
     blockSize = [tpb, tpb, tpb]
@@ -131,6 +136,8 @@ def SDF3D(u, norm=2.0, tpb=8):
     numpy.ndarray
         Signed distance field of ``u``.
     """
+    if not cuda_available():
+        return cpu_ops.SDF3D(u, norm)
     dims = u.shape
     gridSize = [(dims[0] + tpb - 1) // tpb, (dims[1] + tpb - 1) // tpb, (dims[2] + tpb - 1) // tpb]
     blockSize = [tpb, tpb, tpb]
@@ -164,6 +171,8 @@ def simplifyKernel(d_u,d_v):
 
 def simplify(u, tpb=8):
     """Remove thin layers from ``u`` for faster distance computations."""
+    if not cuda_available():
+        return cpu_ops.simplify(u)
     d_u = cuda.to_device(u)
     dims = u.shape
     d_v = cuda.device_array(dims, dtype=np.float32)
@@ -194,6 +203,8 @@ def xHeight(u, tpb=8):
     numpy.ndarray
         Field where each voxel stores the height of material above it.
     """
+    if not cuda_available():
+        return cpu_ops.xHeight(u)
     m, n, p = u.shape
     TPBY, TPBZ = tpb, tpb
     gridDims = (n + TPBY - 1) // TPBY, (p + TPBZ - 1) // TPBZ

--- a/app/voronizer/analysis.py
+++ b/app/voronizer/analysis.py
@@ -7,6 +7,9 @@ voronizer pipeline but can be imported directly.
 
 from numba import cuda
 
+from . import cpu_ops
+from .backend import cuda_available
+
 
 @cuda.reduce
 def sum_reduce(a, b):
@@ -34,6 +37,8 @@ def findVol(u, scale, MAT_DENSITY, name, tpb=8):
     float
         The computed volume in ``mm^3``.
     """
+    if not cuda_available():
+        return cpu_ops.findVol(u, scale, MAT_DENSITY, name)
     cellVol = scale[0]*scale[1]*scale[2]
     d_u = cuda.to_device(u)
     dims = u.shape

--- a/app/voronizer/backend.py
+++ b/app/voronizer/backend.py
@@ -1,0 +1,27 @@
+"""Compute backend selection for the voronizer pipeline.
+
+The voronizer was originally written with numba CUDA kernels.  On machines
+without an NVIDIA GPU (e.g. Apple Silicon) the pipeline transparently falls
+back to NumPy/SciPy implementations in :mod:`app.voronizer.cpu_ops`.
+
+Set the environment variable ``CRISTIFY_FORCE_CPU=1`` to force the CPU
+backend even when CUDA is available (useful for testing).
+"""
+
+import os
+
+_cuda_available = None
+
+
+def cuda_available() -> bool:
+    """Return ``True`` when a usable CUDA GPU is present."""
+    global _cuda_available
+    if os.environ.get("CRISTIFY_FORCE_CPU"):
+        return False
+    if _cuda_available is None:
+        try:
+            from numba import cuda
+            _cuda_available = bool(cuda.is_available())
+        except Exception:
+            _cuda_available = False
+    return _cuda_available

--- a/app/voronizer/cpu_ops.py
+++ b/app/voronizer/cpu_ops.py
@@ -1,0 +1,277 @@
+"""NumPy/SciPy implementations of the voronizer CUDA kernels.
+
+Each function mirrors the semantics of its GPU counterpart in
+:mod:`app.voronizer.Frep`, :mod:`app.voronizer.SDF3D`,
+:mod:`app.voronizer.pointGen`, :mod:`app.voronizer.voronize`,
+:mod:`app.voronizer.voxelize`, :mod:`app.voronizer.analysis` and
+:mod:`app.voronizer.visualizeSlice`.  They are used automatically when no
+CUDA capable GPU is available (see :mod:`app.voronizer.backend`).
+"""
+
+import numpy as np
+from scipy import ndimage
+
+_NEIGHBOR_OFFSETS = [
+    (dx, dy, dz)
+    for dx in (-1, 0, 1)
+    for dy in (-1, 0, 1)
+    for dz in (-1, 0, 1)
+    if (dx, dy, dz) != (0, 0, 0)
+]
+
+
+def smooth(u, iteration=1, buffer=0):
+    """Average each voxel with its 26 neighbors, ``iteration`` times."""
+    u = np.array(u, dtype=np.float32)
+    kernel = np.ones((3, 3, 3))
+    counts = ndimage.convolve(np.ones(u.shape), kernel, mode="constant", cval=0.0)
+    for _ in range(iteration):
+        v = (ndimage.convolve(u.astype(np.float64), kernel, mode="constant", cval=0.0) / counts).astype(np.float32)
+        if buffer > 0:
+            inner = (
+                slice(buffer, u.shape[0] - buffer),
+                slice(buffer, u.shape[1] - buffer),
+                slice(buffer, u.shape[2] - buffer),
+            )
+            out = u.copy()
+            out[inner] = v[inner]
+            v = out
+        u = v
+    return u
+
+
+def union(u, v):
+    """Voxel-wise union of two signed fields (element-wise minimum)."""
+    return np.minimum(u, v)
+
+
+def intersection(u, v):
+    """Voxel-wise intersection (element-wise maximum)."""
+    return np.maximum(u, v)
+
+
+def subtract(u, v):
+    """Subtract ``u`` (cutting tool) from ``v`` (base model)."""
+    return np.maximum(-np.asarray(u), v)
+
+
+def projection(u):
+    """Project ``u`` downwards along the X axis until contact."""
+    u = np.array(u)
+    minX = 0
+    while np.amin(u[minX]) >= 0:
+        minX += 1
+    for X in range(u.shape[0] - 2, minX - 1, -1):
+        u[X][u[X + 1] <= 0] = -1
+    return u
+
+
+def translate(u, x, y, z):
+    """Translate ``u`` by integer voxel offsets with wraparound."""
+    return np.roll(np.asarray(u, dtype=np.float32), (x, y, z), axis=(0, 1, 2))
+
+
+def condense(u, buffer, tpb=8):
+    """Crop empty space around ``u`` leaving ``buffer`` voxels of padding.
+
+    Output dimensions are rounded up to a multiple of ``tpb`` to match the
+    GPU implementation.
+    """
+    u = np.asarray(u)
+    neg = np.argwhere(u < 0)
+    mins = neg.min(axis=0)
+    maxs = neg.max(axis=0)
+    sizes = [
+        int(np.ceil((2 * buffer + maxs[a] - mins[a]) / tpb) * tpb)
+        for a in range(3)
+    ]
+    fill = np.float32(max(np.max(u), 0.01))
+    out = np.full(sizes, fill, dtype=np.float32)
+    src_slices = []
+    dst_slices = []
+    for a in range(3):
+        start = mins[a] - buffer
+        src_start = max(start, 0)
+        dst_start = src_start - start
+        length = min(u.shape[a] - src_start, sizes[a] - dst_start)
+        src_slices.append(slice(src_start, src_start + length))
+        dst_slices.append(slice(dst_start, dst_start + length))
+    out[tuple(dst_slices)] = u[tuple(src_slices)]
+    return out
+
+
+def _grids(x, y, z, cx=0.0, cy=0.0, cz=0.0):
+    X = (np.asarray(x, dtype=np.float64) - cx)[:, None, None]
+    Y = (np.asarray(y, dtype=np.float64) - cy)[None, :, None]
+    Z = (np.asarray(z, dtype=np.float64) - cz)[None, None, :]
+    return X, Y, Z
+
+
+def heart(x, y, z, cx, cy, cz):
+    """Heart shaped SDF over the given coordinate vectors."""
+    X, Y, Z = _grids(x, y, z, cx, cy, cz)
+    u = (X**2 + 9 * Y**2 / 4 + Z**2 - 1) ** 3 - X**2 * Z**3 - 9 * Y**2 * Z**3 / 80
+    return u.astype(np.float32)
+
+
+def egg(x, y, z, cx, cy, cz):
+    """Egg shaped SDF."""
+    X, Y, Z = _grids(x, y, z, cx, cy, cz)
+    u = 9 * X**2 + 16 * (Y**2 + Z**2) + 2 * X * (Y**2 + Z**2) + (Y**2 + Z**2) - 144
+    return u.astype(np.float32)
+
+
+def rect(x, y, z, xl, yl, zl, origin=(0, 0, 0)):
+    """Axis-aligned rectangular prism SDF."""
+    X, Y, Z = _grids(x, y, z, *origin)
+    u = np.maximum.reduce([
+        np.broadcast_to(np.abs(X) - xl / 2, (len(x), len(y), len(z))),
+        np.broadcast_to(np.abs(Y) - yl / 2, (len(x), len(y), len(z))),
+        np.broadcast_to(np.abs(Z) - zl / 2, (len(x), len(y), len(z))),
+    ])
+    return u.astype(np.float32)
+
+
+def sphere(x, y, z, rad):
+    """Sphere SDF centered at the origin."""
+    X, Y, Z = _grids(x, y, z)
+    return (np.sqrt(X**2 + Y**2 + Z**2) - rad).astype(np.float32)
+
+
+def cylinderX(x, y, z, start, stop, rad):
+    """Cylinder SDF aligned to the X axis."""
+    X, Y, Z = _grids(x, y, z)
+    height = (X - start) * (X - stop)
+    width = np.sqrt(Y**2 + Z**2) - rad
+    return np.maximum(height, width).astype(np.float32)
+
+
+def cylinderY(x, y, z, start, stop, rad):
+    """Cylinder SDF aligned to the Y axis."""
+    X, Y, Z = _grids(x, y, z)
+    height = (Y - start) * (Y - stop)
+    width = np.sqrt(X**2 + Z**2) - rad
+    return np.maximum(height, width).astype(np.float32)
+
+
+def toFRep(u):
+    """Convert boolean voxels to a simple FRep field."""
+    return np.where(np.asarray(u), np.float32(-0.01), np.float32(0.01))
+
+
+def jumpFlood(u, norm=2.0):
+    """Nearest seed coordinates and distance for every voxel.
+
+    Seeds are the voxels of ``u`` that are ``<= 0``.  Returns an array of
+    shape ``u.shape + (4,)`` holding ``(x, y, z, dist)`` per voxel, matching
+    the GPU jump flooding output.
+    """
+    u = np.asarray(u)
+    dims = u.shape
+    seeds = u <= 0
+    out = np.full(dims + (4,), 1000.0, dtype=np.float32)
+    if not seeds.any():
+        return out
+    if norm == 2.0:
+        dist, idx = ndimage.distance_transform_edt(~seeds, return_indices=True)
+        out[..., 0] = idx[0]
+        out[..., 1] = idx[1]
+        out[..., 2] = idx[2]
+        out[..., 3] = dist
+        return out
+    # Generic Minkowski norms: vectorized jump flooding.
+    ii, jj, kk = np.indices(dims, dtype=np.float32)
+    out[seeds, 0] = ii[seeds]
+    out[seeds, 1] = jj[seeds]
+    out[seeds, 2] = kk[seeds]
+    out[seeds, 3] = 0.0
+    n = int(round(np.log2(max(dims) - 1) + 0.5))
+    steps = [2 ** (n - c - 1) for c in range(n)] + [2, 1]
+    for step in steps:
+        for dx, dy, dz in _NEIGHBOR_OFFSETS:
+            cand = np.roll(out, (dx * step, dy * step, dz * step), axis=(0, 1, 2))
+            d = (
+                np.abs((ii - cand[..., 0]) ** norm)
+                + np.abs((jj - cand[..., 1]) ** norm)
+                + np.abs((kk - cand[..., 2]) ** norm)
+            ) ** (1.0 / norm)
+            better = d < out[..., 3]
+            out[better, :3] = cand[better, :3]
+            out[better, 3] = d[better]
+    return out
+
+
+def SDF3D(u, norm=2.0):
+    """Convert a binary volume to a signed distance field."""
+    u = np.asarray(u)
+    pos = jumpFlood(u, norm)
+    neg = jumpFlood(-u, norm)
+    dp = pos[..., 3]
+    dn = neg[..., 3]
+    return np.where(dp > 0, dp, -dn).astype(np.float32)
+
+
+def simplify(u):
+    """Flatten the field to thin -0.01/0/0.01 bands for faster processing."""
+    u = np.asarray(u)
+    footprint = np.ones((3, 3, 3), dtype=bool)
+    footprint[1, 1, 1] = False
+    nmax = ndimage.maximum_filter(u, footprint=footprint, mode="nearest")
+    nmin = ndimage.minimum_filter(u, footprint=footprint, mode="nearest")
+    out = np.where(u <= 0, np.float32(-0.01), np.float32(0.01))
+    out[(u <= 0) & (nmax > 0) & (nmin < 0)] = 0.0
+    return out.astype(np.float32)
+
+
+def xHeight(u):
+    """Cumulative height of solid voxels along X."""
+    v = simplify(u)
+    for i in range(v.shape[0] - 2, 0, -1):
+        mask = v[i] <= 0
+        v[i][mask] = np.minimum(-1.0, v[i + 1][mask] - 1.0)
+    return v
+
+
+def genRandPoints(u, threshold):
+    """Random seed points inside ``u`` (zeros mark points, ones elsewhere)."""
+    u = np.asarray(u)
+    x, y, z = u.shape
+    threshold = threshold / max(x, y, z)
+    r = np.random.rand(x, y, z)
+    v = np.ones(u.shape)
+    with np.errstate(divide="ignore"):
+        mask = (u < 0) & (r < threshold / np.abs(u))
+    v[mask] = 0
+    print(str(int(x * y * z - v.sum() + 0.5)) + " Points")
+    return v
+
+
+def wallFinder(points):
+    """Mark voxels whose nearest seed differs from a neighbor's as walls."""
+    points = np.asarray(points)
+    seeds = points[..., :3]
+    walls = np.ones(points.shape[:3])
+    for offset in _NEIGHBOR_OFFSETS:
+        shifted = np.roll(seeds, offset, axis=(0, 1, 2))
+        walls[np.any(shifted != seeds, axis=-1)] = -1
+    return walls
+
+
+def findVol(u, scale, MAT_DENSITY, name):
+    """Volume (mm^3) and mass of the solid voxels of ``u``."""
+    cellVol = scale[0] * scale[1] * scale[2]
+    count = np.count_nonzero(np.asarray(u) <= 0)
+    vol = cellVol * count
+    print(name + " Volume = " + str(round(vol, 2)) + " mm^3")
+    print(name + " Mass = " + str(round(MAT_DENSITY * vol / 1000, 2)) + " g")
+    return vol
+
+
+def setColor(u, color, background):
+    """RGB image stack for ``u`` (solid voxels get ``color``)."""
+    u = np.asarray(u)
+    image = np.empty(u.shape + (3,), dtype=np.uint8)
+    solid = u < 0
+    for i in range(3):
+        image[..., i] = np.where(solid, color[i], background[i])
+    return image

--- a/app/voronizer/meshExport.py
+++ b/app/voronizer/meshExport.py
@@ -50,8 +50,7 @@ def exportPLY(modelName, verts2, faces):
     
 # Compute a tesselation of the zero isosurface
 def tesselate(fvals, xvals, yvals, zvals, scale):
-    #verts,faces,normals,values = measure.marching_cubes_lewiner(fvals,0,spacing=(1.0, 1.0, 1.0),allow_degenerate=False)
-    verts, faces, normals, values = measure.marching_cubes_lewiner(fvals, level = 0,spacing=(1.0, 1.0, 1.0), allow_degenerate = False)    
+    verts, faces, normals, values = measure.marching_cubes(fvals, level = 0,spacing=(1.0, 1.0, 1.0), allow_degenerate = False, method = "lewiner")
     ndex = [0,0,0]
     frac = [0,0,0]
     verts2 = np.ndarray(shape=(verts.size//3,3), dtype=float)

--- a/app/voronizer/pointGen.py
+++ b/app/voronizer/pointGen.py
@@ -2,6 +2,9 @@ from numba import cuda
 import numpy as np
 from .Frep import union
 
+from . import cpu_ops
+from .backend import cuda_available
+
 @cuda.reduce
 def sum_reduce(a, b):
     return a + b
@@ -20,6 +23,8 @@ def genRandPoints(u, threshold, tpb=8):
     #u = Voxel model of boundary object.
     #threshold = normalized value to determine how likely it is for each voxel to have a point placed in it.
     #Outputs a matrix with random points within the boundaries of object u.  The random points are set to 0 while the rest of the matrix is ones.
+    if not cuda_available():
+        return cpu_ops.genRandPoints(u, threshold)
     x,y,z = u.shape
     threshold=threshold/max(x,y,z) 
     TPBX = TPBY = TPBZ = tpb

--- a/app/voronizer/visualizeSlice.py
+++ b/app/voronizer/visualizeSlice.py
@@ -4,6 +4,9 @@ import numpy as np
 from numba import cuda
 from PIL import Image
 
+from . import cpu_ops
+from .backend import cuda_available
+
 def slicePlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x"):
     #Plots a slice of matrix u cut at sliceLocation, with the negative values (voxels inside the object) set to teal.
     fig, ax = plt.subplots()
@@ -72,6 +75,8 @@ def setColor(u, color, background, tpb=8):
     #u = 3D voxel representation of model
     #color = [R,G,B] value desired for that model
     #background = [R,G,B] value desired for voxels outside of the model
+    if not cuda_available():
+        return cpu_ops.setColor(u, color, background)
     x,y,z = u.shape
     TPBX = TPBY = TPBZ = tpb
     d_u = cuda.to_device(u)

--- a/app/voronizer/voronize.py
+++ b/app/voronizer/voronize.py
@@ -4,6 +4,9 @@ from .SDF3D import SDF3D, jumpFlood
 from numba import cuda
 import numpy as np
 
+from . import cpu_ops
+from .backend import cuda_available
+
 def voronize(
     origObject,
     seedPoints,
@@ -32,7 +35,7 @@ def voronize(
     seedPoints = jumpFlood(seedPoints, order)
     if name !="":
         contourPlot(seedPoints[:,:,:,3],sliceLocation,titlestring="SDF of the Points for "+name,axis = sliceAxis)
-    voronoi = wallFinder(seedPoints)
+    voronoi = wallFinder(seedPoints, tpb)
     voronoi = SDF3D(voronoi)
     if name !="":
         slicePlot(voronoi,sliceLocation,titlestring="Voronoi Structure for "+name,axis = sliceAxis)
@@ -64,11 +67,13 @@ def wallFinderKernel(d_points,d_walls):
             if m!=m1 or n!=n1 or p!=p1:
                 d_walls[i,j,k]=-1
         
-def wallFinder(voxel):
+def wallFinder(voxel, tpb=8):
     #voxel = the original voxel model of the object
     #gradient = the gradient field of the object
-    #Outputs a voxel model with material where the gradient was below the 
+    #Outputs a voxel model with material where the gradient was below the
     #threshold.
+    if not cuda_available():
+        return cpu_ops.wallFinder(voxel)
     dims = voxel.shape
     d_points = cuda.to_device(voxel)
     d_walls = cuda.to_device(np.ones(dims[:3]))

--- a/app/voronizer/voxelize.py
+++ b/app/voronizer/voxelize.py
@@ -4,6 +4,9 @@ import numpy as np
 from struct import unpack
 from operator import itemgetter
 
+from . import cpu_ops
+from .backend import cuda_available
+
 # From https://github.com/cpederkoff/stl-to-voxel
 
 def voxelize(inputFilePath, resolution, buffer, tpb=8):
@@ -325,6 +328,8 @@ def toFRepKernel(d_u,d_v):
 
 def toFRep(u, tpb=8):
     """Convert boolean voxels to a simple FRep field."""
+    if not cuda_available():
+        return cpu_ops.toFRep(u)
     d_u = cuda.to_device(u)
     dims = u.shape
     d_v = cuda.device_array(dims, dtype=np.float32)

--- a/tests/test_cpu_ops.py
+++ b/tests/test_cpu_ops.py
@@ -1,0 +1,131 @@
+"""Tests for the CPU fallback of the voronizer pipeline."""
+
+import numpy as np
+import pytest
+
+from app.voronizer import backend, cpu_ops
+
+
+@pytest.fixture(autouse=True)
+def force_cpu(monkeypatch):
+    monkeypatch.setenv("CRISTIFY_FORCE_CPU", "1")
+
+
+def test_backend_force_cpu():
+    assert backend.cuda_available() is False
+
+
+def test_boolean_ops():
+    u = np.array([[[-1.0, 1.0]]])
+    v = np.array([[[1.0, -1.0]]])
+    assert np.array_equal(cpu_ops.union(u, v), np.array([[[-1.0, -1.0]]]))
+    assert np.array_equal(cpu_ops.intersection(u, v), np.array([[[1.0, 1.0]]]))
+    # subtract removes the cutting tool ``u`` from ``v``
+    assert np.array_equal(cpu_ops.subtract(u, v), np.array([[[1.0, -1.0]]]))
+
+
+def test_translate_wraps():
+    u = np.zeros((3, 3, 3), dtype=np.float32)
+    u[0, 0, 0] = -1
+    v = cpu_ops.translate(u, 1, 0, 0)
+    assert v[1, 0, 0] == -1
+    assert v[0, 0, 0] == 0
+
+
+def test_sphere_sdf_signs():
+    x = np.linspace(-2, 2, 9)
+    u = cpu_ops.sphere(x, x, x, 1.0)
+    assert u[4, 4, 4] < 0  # center is inside
+    assert u[0, 0, 0] > 0  # corner is outside
+
+
+def test_rect_sdf_signs():
+    x = np.linspace(-2, 2, 9)
+    u = cpu_ops.rect(x, x, x, 2, 2, 2)
+    assert u[4, 4, 4] < 0
+    assert u[0, 4, 4] > 0
+
+
+def test_toFRep():
+    u = np.zeros((2, 2, 2), dtype=bool)
+    u[0, 0, 0] = True
+    v = cpu_ops.toFRep(u)
+    assert v[0, 0, 0] == np.float32(-0.01)
+    assert v[1, 1, 1] == np.float32(0.01)
+
+
+def test_jumpFlood_distances():
+    u = np.ones((8, 8, 8), dtype=np.float32)
+    u[4, 4, 4] = -1  # single seed
+    out = cpu_ops.jumpFlood(u)
+    assert out[4, 4, 4, 3] == 0
+    assert np.allclose(out[4, 4, 6, :3], [4, 4, 4])
+    assert out[4, 4, 6, 3] == pytest.approx(2.0)
+
+
+def test_SDF3D_signs():
+    u = np.full((8, 8, 8), 0.01, dtype=np.float32)
+    u[3:6, 3:6, 3:6] = -0.01
+    sdf = cpu_ops.SDF3D(u)
+    assert sdf[4, 4, 4] < 0
+    assert sdf[0, 0, 0] > 0
+    assert sdf[0, 0, 0] > sdf[2, 2, 2]  # farther outside, larger distance
+
+
+def test_simplify_bands():
+    u = np.full((6, 6, 6), 1.0, dtype=np.float32)
+    u[2:4, 2:4, 2:4] = -1.0
+    v = cpu_ops.simplify(u)
+    assert set(np.unique(v)) <= {np.float32(-0.01), np.float32(0.0), np.float32(0.01)}
+    assert v[2, 2, 2] == 0  # boundary voxel has both signs around it
+
+
+def test_condense_crops_and_pads():
+    u = np.full((20, 20, 20), 1.0, dtype=np.float32)
+    u[8:12, 8:12, 8:12] = -1.0
+    v = cpu_ops.condense(u, buffer=2, tpb=8)
+    assert all(dim % 8 == 0 for dim in v.shape)
+    assert np.min(v) < 0
+
+
+def test_genRandPoints_inside_only():
+    u = np.full((10, 10, 10), 1.0, dtype=np.float32)
+    u[3:7, 3:7, 3:7] = -0.5
+    pts = cpu_ops.genRandPoints(u, threshold=5.0)
+    outside = pts[u >= 0]
+    assert np.all(outside == 1)
+
+
+def test_findVol(capsys):
+    u = np.full((4, 4, 4), 1.0)
+    u[0, 0, 0] = -1.0
+    vol = cpu_ops.findVol(u, [2.0, 2.0, 2.0], 1.25, "Test")
+    assert vol == pytest.approx(8.0)
+
+
+def test_setColor():
+    u = np.full((2, 2, 2), 1.0)
+    u[0, 0, 0] = -1.0
+    img = cpu_ops.setColor(u, [255, 0, 0], [0, 0, 255])
+    assert tuple(img[0, 0, 0]) == (255, 0, 0)
+    assert tuple(img[1, 1, 1]) == (0, 0, 255)
+
+
+def test_voronize_end_to_end_cpu():
+    """Full voronize() run on a small sphere using the CPU backend."""
+    from app.voronizer import Frep as f
+    from app.voronizer.voronize import voronize
+    from app.voronizer.SDF3D import SDF3D
+
+    x = np.linspace(-2, 2, 24)
+    shape = SDF3D(f.sphere(x, x, x, 1.5))
+    rng = np.random.default_rng(0)
+    seeds = np.ones(shape.shape)
+    seed_idx = rng.integers(4, 20, size=(8, 3))
+    for i, j, k in seed_idx:
+        seeds[i, j, k] = 0
+    result = voronize(shape, seeds, cellThickness=2, shellThickness=1,
+                      scale=[1, 1, 1])
+    assert result.shape == shape.shape
+    assert np.min(result) < 0  # produced solid walls
+    assert np.max(result) > 0  # and empty cells


### PR DESCRIPTION
## Summary
The voronizer previously required an NVIDIA GPU: every operation was implemented as a numba CUDA kernel and crashed with `CudaSupportError` on machines without CUDA (e.g. Apple Silicon). This PR adds a transparent CPU fallback so Voronize works everywhere.

## Key Changes
- **`app/voronizer/backend.py`** — CUDA detection (cached) with a `CRISTIFY_FORCE_CPU=1` env var override for testing.
- **`app/voronizer/cpu_ops.py`** — NumPy/SciPy implementations of all GPU kernels: boolean voxel ops, signed distance fields (exact `distance_transform_edt` for the euclidean norm, vectorized jump flooding for other norms), smoothing, condense, shape primitives, seed point generation, Voronoi wall finding, volume analysis and image coloring.
- Every public voronizer function now dispatches to the CPU backend when CUDA is unavailable; the GPU path is unchanged.

## Bug fixes uncovered along the way
- `voronize.wallFinder` referenced an undefined `tpb` variable (`NameError` even on GPU).
- `meshExport.py` called `measure.marching_cubes_lewiner`, removed from scikit-image years ago; now uses `measure.marching_cubes(..., method="lewiner")`, restoring `.ply` export.

## Testing
- New `tests/test_cpu_ops.py` with 14 tests, including an end-to-end CPU voronize run on a sphere.
- Full suite: 48 tests passing, 0 warnings. Since CI runners have no GPU, the CPU path is now exercised on every PR.

https://claude.ai/code/session_011hK14qH58ybksMu5Mh9B3o

---
_Generated by [Claude Code](https://claude.ai/code/session_011hK14qH58ybksMu5Mh9B3o)_