### PR TITLE
Make voronizer I/O portable and non-interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ for full details.
 # Cristify an STL file
 python -m app.cli cristify --input INPUT.stl --output OUTPUT.stl
 
-# Voronize a model
-python -m app.cli voronize --file-name model.stl --model
+# Voronize a model (use --export to write the resulting .ply,
+# --output-dir to choose where generated files go; default ./Output)
+python -m app.cli voronize --file-name path/to/model.stl --model --export
 # Voronize uses CUDA when an NVIDIA GPU is available and otherwise falls
 # back to a NumPy/SciPy implementation (e.g. on Apple Silicon). Set
 # CRISTIFY_FORCE_CPU=1 to force the CPU backend.

--- a/app/cli.py
+++ b/app/cli.py
@@ -28,12 +28,15 @@ def build_parser() -> argparse.ArgumentParser:
     cristify.add_argument("--floor", type=float, default=None, help="Optional minimum coordinate after projection")
 
     voro = sub.add_parser("voronize", help="Run Voronizer pipeline")
-    voro.add_argument("--file-name", default="", help="STL file name inside Input folder")
+    voro.add_argument("--file-name", default="", help="Path to the input STL file")
     voro.add_argument("--primitive-type", default="", help="Primitive shape type")
     voro.add_argument("--resolution", type=int, default=300)
     voro.add_argument("--tpb", type=int, default=8)
     voro.add_argument("--model", action="store_true", default=False)
     voro.add_argument("--support", action="store_true", default=False)
+    voro.add_argument("--output-dir", default="", help="Directory for generated files (default: ./Output)")
+    voro.add_argument("--export", action="store_true", default=False, help="Export the resulting mesh as .ply")
+    voro.add_argument("--export-name", default="", help="Base name for the exported mesh")
 
     repair = sub.add_parser("repair", help="Repair a mesh")
     repair.add_argument("--input", required=True, help="Path to input mesh file")
@@ -83,6 +86,9 @@ def main(args: Sequence[str] | None = None) -> int:
             TPB=opts.tpb,
             MODEL=opts.model,
             SUPPORT=opts.support,
+            OUTPUT_DIR=opts.output_dir,
+            EXPORT_MESH=opts.export,
+            EXPORT_NAME=opts.export_name,
         )
         run_pipeline(config)
     elif opts.command == "repair":

--- a/app/voronizer/__init__.py
+++ b/app/voronizer/__init__.py
@@ -26,6 +26,9 @@ class PipelineConfig:
     SUPPORT_CELL: float = 0.7
     FILE_NAME: str = ""
     PRIMITIVE_TYPE: str = ""
+    OUTPUT_DIR: str = ""
+    EXPORT_MESH: bool = False
+    EXPORT_NAME: str = ""
 
 
 def run_pipeline(config: PipelineConfig) -> None:

--- a/app/voronizer/main.py
+++ b/app/voronizer/main.py
@@ -13,7 +13,7 @@ Typical usage::
     run(PipelineConfig(FILE_NAME="model.stl"))
 """
 
-import os  # Just used to set up file directory
+import os
 import time
 import numpy as np
 from . import Frep as f
@@ -25,6 +25,32 @@ from .analysis import findVol
 from .visualizeSlice import slicePlot, contourPlot, generateImageStack
 from .voxelize import voxelize
 from .__init__ import PipelineConfig
+
+
+def resolve_input(file_name: str) -> str:
+    """Resolve ``file_name`` to an existing STL path.
+
+    Accepts absolute paths or paths relative to the current working
+    directory.  Falls back to the legacy ``Input/`` folder next to this
+    module for backwards compatibility.
+    """
+    if os.path.isfile(file_name):
+        return file_name
+    legacy = os.path.join(os.path.dirname(__file__), 'Input', file_name)
+    if os.path.isfile(legacy):
+        return legacy
+    raise FileNotFoundError("Input file not found: " + file_name)
+
+
+def resolve_output_dir(config: PipelineConfig) -> str:
+    """Return the output directory for ``config``, creating it if needed.
+
+    Defaults to ``Output/`` in the current working directory when
+    ``config.OUTPUT_DIR`` is empty.
+    """
+    out = config.OUTPUT_DIR or os.path.join(os.getcwd(), 'Output')
+    os.makedirs(out, exist_ok=True)
+    return out
 
 
 def main(config: PipelineConfig) -> None:
@@ -43,10 +69,7 @@ def main(config: PipelineConfig) -> None:
         output files and displaying plots.
     """
     start = time.time()
-    try:
-        os.mkdir(os.path.join(os.path.dirname(__file__), 'Output'))
-    except Exception:
-        pass
+    outputDir = resolve_output_dir(config)
     FILE_NAME = config.FILE_NAME
     PRIMITIVE_TYPE = config.PRIMITIVE_TYPE
     modelImport = False
@@ -55,11 +78,12 @@ def main(config: PipelineConfig) -> None:
         print("You need at least the model or the support structure.")
         return
     if FILE_NAME != "":
-        shortName = FILE_NAME[:-4]
+        shortName = os.path.splitext(os.path.basename(FILE_NAME))[0]
         modelImport = True
-        try:    filepath = os.path.join(os.path.dirname(__file__), 'Input',FILE_NAME)
-        except: 
-            print("Input file not found.") 
+        try:
+            filepath = resolve_input(FILE_NAME)
+        except FileNotFoundError as exc:
+            print(exc)
             return
         res = config.RESOLUTION - config.BUFFER * 2
         origShape, objectBox = voxelize(filepath, res, config.BUFFER, config.TPB)
@@ -147,46 +171,42 @@ def main(config: PipelineConfig) -> None:
     if config.SUPPORT and config.MODEL:
         complete = f.union(objectVoronoi, supportVoronoi, config.TPB)
         if config.IMG_STACK:
-            generateImageStack(objectVoronoi,[255,0,0],supportVoronoi,[0,0,255],name = shortName)
+            generateImageStack(objectVoronoi,[255,0,0],supportVoronoi,[0,0,255],name = shortName,outputDir=outputDir)
     elif config.SUPPORT:
         complete = supportVoronoi
         if config.IMG_STACK:
-            generateImageStack(supportVoronoi,[0,0,0],supportVoronoi,[0,0,255],name = shortName)
+            generateImageStack(supportVoronoi,[0,0,0],supportVoronoi,[0,0,255],name = shortName,outputDir=outputDir)
     elif config.MODEL:
         complete = objectVoronoi
         if config.IMG_STACK:
-            generateImageStack(objectVoronoi,[255,0,0],objectVoronoi,[0,0,0],name = FILE_NAME[:-4])
+            generateImageStack(objectVoronoi,[255,0,0],objectVoronoi,[0,0,0],name = shortName,outputDir=outputDir)
     slicePlot(complete, origShape.shape[0]//2, titlestring='Full Model', axis = "X")
     slicePlot(complete, origShape.shape[1]//2, titlestring='Full Model', axis = "Y")
     slicePlot(complete, origShape.shape[2]//2, titlestring='Full Model', axis = "Z")
     
     print("That took "+str(round(time.time()-start,2))+" seconds.")
-    UIP = input("Would you like the .ply for this iteration? [Y/N]")
-    if UIP == "Y" or UIP == "y":
-        if modelImport:
-            fn = shortName
-        else:
-            fn = input("What would you like the file to be called?")
+    if config.EXPORT_MESH:
+        fn = config.EXPORT_NAME or shortName
         print("Generating Model...")
         if config.SEPARATE_SUPPORTS and config.SUPPORT and config.MODEL:
             if config.SMOOTH:
                 objectVoronoi = f.smooth(objectVoronoi, tpb=config.TPB)
-            generateMesh(objectVoronoi,scale,modelName=fn)
+            generateMesh(objectVoronoi,scale,modelName=fn,outputDir=outputDir)
             print("Generating Supports...")
             if config.SMOOTH:
                 supportVoronoi = f.smooth(supportVoronoi, tpb=config.TPB)
-            generateMesh(supportVoronoi,scale,modelName=fn+"Support")
+            generateMesh(supportVoronoi,scale,modelName=fn+"Support",outputDir=outputDir)
         else:
             if config.SMOOTH:
                 complete = f.smooth(complete, tpb=config.TPB)
-            generateMesh(complete,scale,modelName=fn)
+            generateMesh(complete,scale,modelName=fn,outputDir=outputDir)
         if config.INVERSE and config.MODEL:
             print("Generating Inverse...")
             inv = f.subtract(objectVoronoi, origShape, config.TPB)
             if config.SMOOTH:
                 inv = f.smooth(inv, tpb=config.TPB)
             print("Generating Mesh...")
-            generateMesh(inv,scale,modelName=fn+"Inv")
+            generateMesh(inv,scale,modelName=fn+"Inv",outputDir=outputDir)
 
 if __name__ == '__main__':
     main(PipelineConfig())

--- a/app/voronizer/meshExport.py
+++ b/app/voronizer/meshExport.py
@@ -7,7 +7,7 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 # Create 3d contourplot (and surface tesselation) based on 3d array fvals 
 # sampled on grid with coords determined by xvals, yvals, and zvals
 # Note that tesselator requires inputs corresponding to grid spacings
-def generateMesh(fvals, scale, modelName='', show = False):
+def generateMesh(fvals, scale, modelName='', show = False, outputDir=None):
     i,j,k = fvals.shape
     xvals = np.linspace(0,i-1, i, endpoint=True)
     yvals = np.linspace(0,j-1, j, endpoint=True) 
@@ -15,8 +15,8 @@ def generateMesh(fvals, scale, modelName='', show = False):
     verts, faces = tesselate(fvals, xvals, yvals, zvals, scale)    
     print("Done Tesselate")
     if modelName !='':
-        exportPLY(modelName, verts, faces)	
-        print('Object exported to Output folder as '+modelName+'.ply')
+        filepath = exportPLY(modelName, verts, faces, outputDir)
+        print('Object exported as '+filepath)
     if show:
         fig = plt.figure(figsize=(10, 10))
         ax = fig.add_subplot(111, projection='3d')
@@ -29,8 +29,11 @@ def generateMesh(fvals, scale, modelName='', show = False):
         plt.tight_layout()
         plt.show()    
     
-def exportPLY(modelName, verts2, faces):
-    filepath = os.path.join(os.path.dirname(__file__),'Output',modelName+'.ply')
+def exportPLY(modelName, verts2, faces, outputDir=None):
+    if outputDir is None:
+        outputDir = os.path.join(os.getcwd(), 'Output')
+    os.makedirs(outputDir, exist_ok=True)
+    filepath = os.path.join(outputDir, modelName+'.ply')
     plyf = open(filepath, 'w')
     plyf.write( "ply\n")
     plyf.write( "format ascii 1.0\n")
@@ -45,8 +48,9 @@ def exportPLY(modelName, verts2, faces):
     for i in range(0,verts2.size//3):
         plyf.write(str(verts2[i][0])+' '+str(verts2[i][1])+' '+str(verts2[i][2])+'\n')
     for i in range(0,faces.size//3):
-        plyf.write('3 '+str(faces[i][0])+' '+str(faces[i][1])+' '+str(faces[i][2])+'\n') 
+        plyf.write('3 '+str(faces[i][0])+' '+str(faces[i][1])+' '+str(faces[i][2])+'\n')
     plyf.close()
+    return filepath
     
 # Compute a tesselation of the zero isosurface
 def tesselate(fvals, xvals, yvals, zvals, scale):

--- a/app/voronizer/visualizeSlice.py
+++ b/app/voronizer/visualizeSlice.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-import os  # Just used to set up file directory
+import os
 import numpy as np
 from numba import cuda
 from PIL import Image
@@ -7,7 +7,14 @@ from PIL import Image
 from . import cpu_ops
 from .backend import cuda_available
 
-def slicePlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x"):
+
+def _output_dir(outputDir):
+    if outputDir is None:
+        outputDir = os.path.join(os.getcwd(), 'Output')
+    os.makedirs(outputDir, exist_ok=True)
+    return outputDir
+
+def slicePlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x",outputDir=None):
     #Plots a slice of matrix u cut at sliceLocation, with the negative values (voxels inside the object) set to teal.
     fig, ax = plt.subplots()
     if axis.upper()=="X":
@@ -20,9 +27,9 @@ def slicePlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x"):
     ax.set_aspect(1.0)
     plt.show()
     if save:
-        fig.savefig(os.path.join(os.path.dirname(__file__),'Output',titlestring+'.png'))
-        
-def contourPlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x"):
+        fig.savefig(os.path.join(_output_dir(outputDir),titlestring+'.png'))
+
+def contourPlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x",outputDir=None):
     #Plots a slice of matrix u cut at sliceLocation
     fig, ax = plt.subplots()
     if axis.upper()=="X":
@@ -36,9 +43,9 @@ def contourPlot(u,sliceLocation,titlestring='Plot',save=False,axis = "x"):
     ax.set_aspect(1.0)
     plt.show()
     if save:
-        fig.savefig(os.path.join(os.path.dirname(__file__),'Output',titlestring+'.png'))
+        fig.savefig(os.path.join(_output_dir(outputDir),titlestring+'.png'))
 
-def generateImageStack(model,modelColor,support,supportColor,sliceLocations=[],background=[0,0,0],name="Model"):
+def generateImageStack(model,modelColor,support,supportColor,sliceLocations=[],background=[0,0,0],name="Model",outputDir=None):
     #model = 3D voxel representation of model
     #modelColor = [R,G,B] color for model
     #support = 3D voxel representation of support
@@ -48,8 +55,8 @@ def generateImageStack(model,modelColor,support,supportColor,sliceLocations=[],b
     #name = name of the model, defaults to Model
     x,y,z = support.shape
     print("Generating image stack...")
-    try: os.mkdir(os.path.join(os.path.dirname(__file__),'Output',name+" image stack"))
-    except: pass
+    stackDir = os.path.join(_output_dir(outputDir),name+" image stack")
+    os.makedirs(stackDir, exist_ok=True)
     imageModel = setColor(model,modelColor,background)
     imageSupport = setColor(support,supportColor,background)
     completePicture = imageSupport+imageModel
@@ -58,7 +65,7 @@ def generateImageStack(model,modelColor,support,supportColor,sliceLocations=[],b
     for val in sliceLocations:
         picture = completePicture[val,:,:,:]
         img = Image.fromarray(picture, 'RGB')
-        img.save(os.path.join(os.path.dirname(__file__),'Output',name+" image stack",str(val)+name+'.png'))
+        img.save(os.path.join(stackDir,str(val)+name+'.png'))
     print("Image Stack Complete!")
     
 @cuda.jit

--- a/tests/test_voronizer_io.py
+++ b/tests/test_voronizer_io.py
@@ -1,0 +1,87 @@
+"""Tests for portable input/output handling in the voronizer pipeline."""
+
+import numpy as np
+import pytest
+import trimesh
+
+from app.cli import parse_args
+from app.voronizer import PipelineConfig, run_pipeline
+from app.voronizer.main import resolve_input, resolve_output_dir
+
+
+@pytest.fixture(autouse=True)
+def headless(monkeypatch):
+    monkeypatch.setenv("CRISTIFY_FORCE_CPU", "1")
+    monkeypatch.setenv("MPLBACKEND", "Agg")
+
+
+def _write_box_stl(path):
+    mesh = trimesh.creation.box(extents=(10, 10, 10))
+    mesh.export(str(path))
+    return path
+
+
+def test_resolve_input_accepts_path(tmp_path):
+    stl = _write_box_stl(tmp_path / "box.stl")
+    assert resolve_input(str(stl)) == str(stl)
+
+
+def test_resolve_input_missing_file():
+    with pytest.raises(FileNotFoundError):
+        resolve_input("definitely_not_there.stl")
+
+
+def test_resolve_output_dir_creates_custom_dir(tmp_path):
+    out = tmp_path / "my_output"
+    cfg = PipelineConfig(OUTPUT_DIR=str(out))
+    assert resolve_output_dir(cfg) == str(out)
+    assert out.is_dir()
+
+
+def test_resolve_output_dir_defaults_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = PipelineConfig()
+    result = resolve_output_dir(cfg)
+    assert result == str(tmp_path / "Output")
+    assert (tmp_path / "Output").is_dir()
+
+
+def test_missing_input_reports_error(tmp_path, capsys):
+    cfg = PipelineConfig(FILE_NAME="missing.stl", MODEL=True,
+                         OUTPUT_DIR=str(tmp_path))
+    run_pipeline(cfg)
+    assert "Input file not found" in capsys.readouterr().out
+
+
+def test_cli_parses_io_flags():
+    opts = parse_args([
+        "voronize",
+        "--file-name", "/tmp/model.stl",
+        "--model",
+        "--output-dir", "/tmp/out",
+        "--export",
+        "--export-name", "result",
+    ])
+    assert opts.file_name == "/tmp/model.stl"
+    assert opts.output_dir == "/tmp/out"
+    assert opts.export is True
+    assert opts.export_name == "result"
+
+
+def test_pipeline_exports_ply_to_custom_dir(tmp_path):
+    """Full non-interactive pipeline run from an arbitrary STL path."""
+    import matplotlib
+    matplotlib.use("Agg")
+    np.random.seed(0)
+    stl = _write_box_stl(tmp_path / "box.stl")
+    out = tmp_path / "results"
+    cfg = PipelineConfig(
+        FILE_NAME=str(stl),
+        MODEL=True,
+        RESOLUTION=24,
+        MODEL_THRESH=50,
+        EXPORT_MESH=True,
+        OUTPUT_DIR=str(out),
+    )
+    run_pipeline(cfg)
+    assert (out / "box_Voronoi.ply").is_file()


### PR DESCRIPTION
## Summary
The voronizer pipeline had hardcoded, non-portable I/O: it only read STL files from an `Input/` folder inside the package, wrote all results into the package directory, and blocked on an interactive `input()` prompt to export meshes. This PR makes it usable from any path and fully scriptable.

## Key Changes
- **Input**: `FILE_NAME` now accepts any path (absolute or relative to the working directory), with a fallback to the legacy `app/voronizer/Input/` folder for backwards compatibility. Missing files fail fast with a clear `Input file not found` message.
- **Output**: new `PipelineConfig.OUTPUT_DIR` (CLI: `--output-dir`), defaulting to `./Output` in the working directory instead of writing inside the installed package. The directory is threaded through `generateMesh`/`exportPLY`, `slicePlot`/`contourPlot` and `generateImageStack`.
- **Non-interactive export**: the `input("Would you like the .ply...?")` prompt is replaced by `EXPORT_MESH`/`EXPORT_NAME` config options (CLI: `--export` / `--export-name`), so the pipeline can run unattended.
- README updated with the new flags.

## Testing
- New `tests/test_voronizer_io.py` (7 tests): path resolution, error reporting, CLI flag parsing, output dir creation, and a full non-interactive pipeline run that exports a `.ply` to a custom directory (exercising the CPU backend in CI).
- Full suite: 55 tests passing.

https://claude.ai/code/session_011hK14qH58ybksMu5Mh9B3o

---
_Generated by [Claude Code](https://claude.ai/code/session_011hK14qH58ybksMu5Mh9B3o)_